### PR TITLE
Add tray-enabled Linux notifier with optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ and (optionally) through Pushover.
   one per unique player that joins you (`OnPlayerJoined`).
 - Debounces duplicate events with configurable cooldowns.
 - Optional Pushover push notifications alongside local toasts.
-- Simple GUI on both Windows (PowerShell/WinForms) and Linux (Python/Tk).
+- Simple GUI on both Windows (PowerShell/WinForms) and Linux (Python/Tk) with tray controls.
 
 ## Windows (PowerShell)
 
@@ -56,6 +56,9 @@ A native Linux port with a Tk GUI is provided in
 - `notify-send` (from `libnotify-bin`) for desktop notifications. When it is
   missing the script falls back to logging the messages.
 - `pgrep` (usually part of `procps`) is used to detect a running VRChat.exe.
+- *(Optional but recommended)* [`pystray`](https://pypi.org/project/pystray/) and
+  [`Pillow`](https://pypi.org/project/Pillow/) enable the task tray icon with
+  quick actions. Install them via `pip install pystray Pillow`.
 
 ### Running
 
@@ -75,6 +78,11 @@ Click **Save & Restart Monitoring** once the folders and keys are set. The
 application remembers the settings in
 `~/.local/share/vrchat-join-notification-with-pushover/config.json` (a pointer file keeps track of
 custom install folders).
+
+When the optional tray dependencies are installed the app adds a task tray icon
+with menu actions to open the settings window, start/stop monitoring and quit.
+Closing the window simply hides it to the tray so monitoring can continue in
+the background.
 
 Desktop notifications mirror the Windows behaviour and Pushover pushes share
 the same cooldown logic, so you will only see one alert per unique event.


### PR DESCRIPTION
## Summary
- detect optional pystray/Pillow dependencies and expose a Linux tray controller
- add tray-aware lifecycle management for the Tk settings window and monitoring loop
- document the optional tray support and dependencies in the README

## Testing
- python3 -m compileall src/vrchat-join-notification-with-pushover_linux.py

------
https://chatgpt.com/codex/tasks/task_e_68cabbbe6a98832ca245b31731174e83