### PR TITLE
Document Arch-specific pip flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,18 @@ python3 -m pip install --user '.[tray]'
 ```
 
 > [!IMPORTANT]
-> Some distributions (such as Arch and Manjaro) mark Python as an
-> [externally managed environment](https://peps.python.org/pep-0668/).
-> On those systems the `--user` installs above will fail with
-> `error: externally-managed-environment`. Use a virtual environment or
-> `pipx` instead, or pass `--break-system-packages` if you understand
-> the risks of overriding your system Python packages.
+> Some distributions (such as Arch, Manjaro, and derivatives like Garuda)
+> mark Python as an [externally managed
+> environment](https://peps.python.org/pep-0668/). On those systems the
+> `--user` installs above fail with `error:
+> externally-managed-environment`. To run the command in one shot, append
+> `--break-system-packages`:
+> ```bash
+> python3 -m pip install --user --break-system-packages '.[tray]'
+> ```
+> Only use that flag if you understand the risks of overriding your system
+> Python packages. As safer alternatives, create a virtual environment or
+> install via `pipx` instead.
 
 Using a virtual environment is also supported and avoids the
 externally-managed-environment restriction:


### PR DESCRIPTION
## Summary
- explain that Arch-based distributions require --break-system-packages when using pip --user installs
- document the exact command users can run on Garuda/Manjaro to install with tray extras safely

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68caf4261e8c832c935b2621a8554d15