### PR TITLE
Add pipx migration note for existing pip installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ pipx install .
 pipx install '.[tray]'
 ```
 
+> [!NOTE]
+> If you previously installed the package with `pip` (including
+> `pip install --user`), remove that copy before switching to `pipx` so
+> the launcher can be created without warnings. Uninstall with `pip
+> uninstall vrchat-join-notification-with-pushover` or delete the old
+> `~/.local/bin/vrchat-join-notifier` script and re-run the `pipx`
+> command.
+
 ### 3. Launch the notifier
 
 Run the command that gets added to your `$PATH`:


### PR DESCRIPTION
## Summary
- note in the Linux pipx installation section that an existing pip-based install should be removed first to avoid symlink warnings

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68caf63217e8832ca0b70e30d2322acf