### PR TITLE
Add desktop notifications when toggling Linux startup entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A cross-platform helper that watches your VRChat logs and notifies you when play
 - Debounces duplicate events with configurable cooldowns.
 - Optional Pushover integration in addition to local desktop notifications.
 - Simple tray-aware GUI on both Windows (PowerShell + WinForms) and Linux (Python + Tk + an optional system tray that disables itself automatically when prerequisites are missing).
-- Linux build offers one-click login startup integration that writes/removes the `.desktop` autostart entry for you.
+- Linux build offers one-click login startup integration that writes/removes the `.desktop` autostart entry for you and confirms the action with a desktop notification.
 
 ## Repository layout
 
@@ -167,6 +167,8 @@ When the tray extras are installed **and** a tray manager is available, the noti
 ### 4. Start automatically on login (optional)
 
 The GUI's **Add to Startup** button creates the autostart entry under `~/.config/autostart/vrchat-join-notifier.desktop`, while **Remove from Startup** deletes it.
+
+Both buttons also trigger a desktop notification so you immediately know whether the action succeeded.
 
 If you prefer to manage it manually, Linux desktop environments follow the [freedesktop.org autostart specification](https://specifications.freedesktop.org/autostart-spec/latest/), so you can launch the notifier automatically by adding a `.desktop` entry to `~/.config/autostart/`. The basic steps are:
 

--- a/src/vrchat_join_notification/app.py
+++ b/src/vrchat_join_notification/app.py
@@ -1314,9 +1314,11 @@ class AppController:
         except Exception as exc:
             messagebox.showerror(APP_NAME, f"Failed to add to startup:\n{exc}")
             self.logger.log(f"Failed to add startup entry: {exc}")
+            self.notifier.send(APP_NAME, f"Failed to add to startup: {exc}")
         else:
             self.status_var.set("Added to startup.")
             self.logger.log(f"Startup entry created at {entry_path}")
+            self.notifier.send(APP_NAME, "Added to startup.")
         finally:
             self._update_startup_buttons()
 
@@ -1328,9 +1330,11 @@ class AppController:
         except Exception as exc:
             messagebox.showerror(APP_NAME, f"Failed to remove from startup:\n{exc}")
             self.logger.log(f"Failed to remove startup entry: {exc}")
+            self.notifier.send(APP_NAME, f"Failed to remove from startup: {exc}")
         else:
             self.status_var.set("Removed from startup.")
             self.logger.log(f"Startup entry removed from {entry_path}")
+            self.notifier.send(APP_NAME, "Removed from startup.")
         finally:
             self._update_startup_buttons()
 


### PR DESCRIPTION
## Summary
- send desktop notifications when the Linux GUI adds or removes the autostart entry, including error cases
- refresh the README to mention the confirmation notification for the Linux startup helper

## Testing
- python -m compileall src/vrchat_join_notification/app.py

------
https://chatgpt.com/codex/tasks/task_e_68cb125161d8832ca12d2057e84def76