### PR TITLE
Add desktop alert when saving Linux settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The GUI opens automatically on the first launch. Configure the following:
 
 Use the **Add to Startup** / **Remove from Startup** buttons if you want the app to manage your desktop login entry automatically.
 
-Click **Save & Restart Monitoring** to begin watching the log file. Settings persist in `config.json` within the chosen install folder. A pointer file (`config-location.txt`) keeps track of custom locations, so you can move the data directory without losing preferences.
+Click **Save & Restart Monitoring** to begin watching the log file. Settings persist in `config.json` within the chosen install folder. A pointer file (`config-location.txt`) keeps track of custom locations, so you can move the data directory without losing preferences. If you simply click **Save** while valid Pushover keys are configured, the Linux build also confirms the change with a desktop notification.
 
 When the tray extras are installed **and** a tray manager is available, the notifier adds a tray icon with quick actions to open the settings window, start/stop monitoring, and exit. Closing the main window simply hides it, allowing the app to continue monitoring in the background. If the environment is missing tray support (no `pystray`/`Pillow` extras or no system tray manager), the app logs the reason, leaves the tray disabled, and you can continue operating it from the main window instead.
 

--- a/src/vrchat_join_notification/app.py
+++ b/src/vrchat_join_notification/app.py
@@ -1354,6 +1354,8 @@ class AppController:
 
     def save_only(self) -> None:
         self._save_config()
+        if self.config.pushover_user and self.config.pushover_token:
+            self.notifier.send(APP_NAME, "Settings saved.")
         self.status_var.set("Settings saved.")
 
     def _save_config(self) -> None:


### PR DESCRIPTION
## Summary
- trigger a desktop notification from the Linux GUI when saving settings with configured Pushover keys
- document the new confirmation behaviour in the README

## Testing
- python -m compileall src/vrchat_join_notification


------
https://chatgpt.com/codex/tasks/task_e_68cb1fe3b5c0832c94ba5c3e55a1cffe