### PR TITLE
Improve Linux GUI layout sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Run the command that gets added to your `$PATH`:
 vrchat-join-notifier
 ```
 
-The GUI opens automatically on the first launch. Configure the following:
+The GUI opens automatically on the first launch and smartly sizes itself so every control stays visible, even with larger desktop scaling. Configure the following:
 
 - **Install Folder (logs/cache):** Location where the app stores its config and log files (`~/.local/share/vrchat-join-notification-with-pushover` by default).
 - **VRChat Log Folder:** Your Proton prefix path containing the VRChat logs. Common Steam installs are detected automatically, but you can browse to a custom directory if needed.


### PR DESCRIPTION
## Summary
- compute the Linux Tk GUI's minimum geometry from the requested layout so controls and status text remain visible
- update the Linux README instructions to mention the smarter default sizing behaviour

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cb21656ba0832cbb2ddfe4c40f3ad5