### PR TITLE
Update Linux app branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Run the command that gets added to your `$PATH`:
 vrchat-join-notifier
 ```
 
-The GUI opens automatically on the first launch and smartly sizes itself so every control stays visible, even with larger desktop scaling. Configure the following:
+The GUI opens automatically on the first launch and smartly sizes itself so every control stays visible, even with larger desktop scaling. The Linux build now identifies itself as **VRChat Join Notification with Pushover (Linux)**, and its window switcher entry shows up as **VRC-Notifier** so it's easy to spot while Alt+Tabbing. Configure the following:
 
 - **Install Folder (logs/cache):** Location where the app stores its config and log files (`~/.local/share/vrchat-join-notification-with-pushover` by default).
 - **VRChat Log Folder:** Your Proton prefix path containing the VRChat logs. Common Steam installs are detected automatically, but you can browse to a custom directory if needed.
@@ -177,7 +177,7 @@ mkdir -p ~/.config/autostart
 cat > ~/.config/autostart/vrchat-join-notifier.desktop <<'EOF'
 [Desktop Entry]
 Type=Application
-Name=VRChat Join Notifier
+Name=VRChat Join Notification with Pushover
 Comment=Watch VRChat logs and notify when friends join.
 Exec=vrchat-join-notifier
 Terminal=false

--- a/src/vrchat_join_notification/app.py
+++ b/src/vrchat_join_notification/app.py
@@ -1,4 +1,4 @@
-"""VRChat Join Notifier (Linux).
+"""VRChat Join Notification with Pushover (Linux).
 
 This module mirrors the behaviour of the Windows PowerShell implementation while
 using a Tkinter GUI, libnotify desktop notifications and Pushover pushes.
@@ -40,7 +40,7 @@ else:  # pragma: no cover - optional dependency
     Image = None  # type: ignore
     ImageDraw = None  # type: ignore
 
-APP_NAME = "VRChat Join Notifier"
+APP_NAME = "VRChat Join Notification with Pushover"
 CONFIG_FILE_NAME = "config.json"
 POINTER_FILE_NAME = "config-location.txt"
 APP_LOG_NAME = "notifier.log"
@@ -1230,6 +1230,12 @@ class AppController:
 
     def _build_ui(self) -> None:
         self.root.title(f"{APP_NAME} (Linux)")
+        self.root.iconname("VRC-Notifier")
+        try:
+            self.root.wm_class("VRC-Notifier", "VRC-Notifier")
+        except tk.TclError:
+            # Some window managers or Tk builds may not support updating the class name.
+            pass
         main = ttk.Frame(self.root, padding=12)
         main.pack(fill=tk.BOTH, expand=True)
 


### PR DESCRIPTION
## Summary
- rename the Linux GUI branding to "VRChat Join Notification with Pushover" so prompts, notifications, and generated desktop entries match the project name
- set the Tk window icon/title metadata so Alt+Tab displays "VRC-Notifier" and keep the title bar consistent on Linux
- document the refreshed naming in the README and update the autostart example

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cb23a5ae88832c902d89b6b16da78a