### PR TITLE
Handle missing Tk wm_class method

### DIFF
--- a/src/vrchat_join_notification/app.py
+++ b/src/vrchat_join_notification/app.py
@@ -1233,7 +1233,7 @@ class AppController:
         self.root.iconname("VRC-Notifier")
         try:
             self.root.wm_class("VRC-Notifier", "VRC-Notifier")
-        except tk.TclError:
+        except (AttributeError, tk.TclError):
             # Some window managers or Tk builds may not support updating the class name.
             pass
         main = ttk.Frame(self.root, padding=12)


### PR DESCRIPTION
## Summary
- avoid crashing when wm_class is unavailable on the Tk root object by also ignoring AttributeError

## Testing
- python -m compileall src/vrchat_join_notification/app.py

------
https://chatgpt.com/codex/tasks/task_e_68cb268db070832c9e7115a98cb8b3f9