### PR TITLE
Handle clearing Pushover keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The GUI opens automatically on the first launch and smartly sizes itself so ever
 
 Use the **Add to Startup** / **Remove from Startup** buttons if you want the app to manage your desktop login entry automatically.
 
-Click **Save & Restart Monitoring** to begin watching the log file. Settings persist in `config.json` within the chosen install folder. A pointer file (`config-location.txt`) keeps track of custom locations, so you can move the data directory without losing preferences. If you simply click **Save** while valid Pushover keys are configured, the Linux build also confirms the change with a desktop notification.
+Click **Save & Restart Monitoring** to begin watching the log file. Settings persist in `config.json` within the chosen install folder. A pointer file (`config-location.txt`) keeps track of custom locations, so you can move the data directory without losing preferences. If you simply click **Save** while valid Pushover keys are configured, the Linux build also confirms the change with a desktop notification. Clearing either Pushover field and saving likewise removes the stored key and treats you to a confirmation toast so you know it was wiped.
 
 When the tray extras are installed **and** a tray manager is available, the notifier adds a tray icon with quick actions to open the settings window, start/stop monitoring, and exit. Closing the main window simply hides it, allowing the app to continue monitoring in the background. If the environment is missing tray support (no `pystray`/`Pillow` extras or no system tray manager), the app logs the reason, leaves the tray disabled, and you can continue operating it from the main window instead.
 


### PR DESCRIPTION
## Summary
- avoid persisting empty Pushover credentials when saving the configuration
- surface stylish desktop notifications when the user clears stored Pushover keys
- document the key removal flow in the README

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cb2d168160832c924821e5997ace58