### PR TITLE
Fix PowerShell dash parsing on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ cd vrchat-join-notification-with-pushover
    ```
 3. Use the tray icon to open **Settings**, configure your VRChat log directory and (optionally) Pushover credentials, then start monitoring.
 
+> [!NOTE]
+> The Windows script now builds its dash characters at runtime from explicit Unicode code points. This preserves the existing behavior while ensuring Windows PowerShell 5.1 parses the file correctly on Shift-JIS based systems.
+
 ---
 
 ## Linux quick start (Python package)


### PR DESCRIPTION
## Summary
- rebuild dash characters in the Windows PowerShell script using explicit Unicode code points to keep parsing safe on Shift-JIS systems
- update README with a note about the Windows script change

## Testing
- not run (PowerShell script change)

------
https://chatgpt.com/codex/tasks/task_e_68cb321b06f0832cbd86b0d4f336ae52