### PR TITLE
Fix Windows tray tooltip initialization

### DIFF
--- a/src/vrchat-join-notification-with-pushover.ps1
+++ b/src/vrchat-join-notification-with-pushover.ps1
@@ -983,7 +983,8 @@ function Get-SessionDescription {
 
 function Update-TrayState {
     $monitoring = ($script:MonitorThread -and $script:MonitorThread.IsAlive)
-    $tooltip = "$AppName – " + ($monitoring ? 'Monitoring' : 'Stopped')
+    $statusText = if($monitoring){ 'Monitoring' } else { 'Stopped' }
+    $tooltip = "$AppName – $statusText"
     if($script:Session.Ready){
         $tooltip += "`n" + (Get-SessionDescription)
     }


### PR DESCRIPTION
## Summary
- replace the ternary operator in Update-TrayState with an if expression so the script runs on Windows PowerShell 5.1

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb3f1b37b0832cb1fdf7ccf2e3c364