### PR TITLE
Fix Windows status table StrictMode crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ cd vrchat-join-notification-with-pushover
 
 > [!NOTE]
 > The rewritten Windows script uses the same parsing and session logic as the Linux edition, including Unicode-safe string handling. All non-ASCII characters (Japanese log phrases, dash variants, etc.) are emitted explicitly so Windows PowerShell 5.1 and `ps2exe` builds remain reliable on localized systems.
+>
+> If a previous build stopped at launch with a `The property 'Text' cannot be found` error, update to this release. The WinForms status table now registers its rows without leaking the intermediate index back to the caller, so StrictMode no longer halts the script.
 
 ---
 

--- a/src/vrchat-join-notification-with-pushover.ps1
+++ b/src/vrchat-join-notification-with-pushover.ps1
@@ -1441,7 +1441,7 @@ function Build-UI {
         param([System.Windows.Forms.TableLayoutPanel]$Table, [string]$LabelText)
         $row = $Table.RowCount
         $Table.RowCount++
-        $Table.RowStyles.Add((New-Object System.Windows.Forms.RowStyle([System.Windows.Forms.SizeType]::AutoSize)))
+        [void]$Table.RowStyles.Add((New-Object System.Windows.Forms.RowStyle([System.Windows.Forms.SizeType]::AutoSize)))
         $label = New-Object System.Windows.Forms.Label
         $label.Text = $LabelText
         $label.AutoSize = $true


### PR DESCRIPTION
## Summary
- suppress the row-style Add() return value so the Windows status labels remain true Label instances under StrictMode
- document the resolved `The property 'Text' cannot be found` startup error in the README for Windows users

## Testing
- python -m compileall src/vrchat_join_notification

------
https://chatgpt.com/codex/tasks/task_e_68cb4040bba0832cb17dba7c380098dc