### PR TITLE
Adjust tray icon search paths for packaged exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ cd vrchat-join-notification-with-pushover
    Invoke-ps2exe -InputFile .\src\vrchat-join-notification-with-pushover.ps1 -OutputFile .\vrchat-join-notification-with-pushover.exe `
      -Title 'VRChat Join Notification with Pushover' -IconFile .\src\vrchat_join_notification\notification.ico -NoConsole -STA -x64
    ```
+   The compiled build now searches next to the executable for both `notification.ico` and `src\notification.ico` (plus their
+   `vrchat_join_notification` subfolder variants), so keep the icon alongside the `.exe` when redistributing a packaged copy.
 3. Open **Settings** from the tray icon (or via the window) to configure the install/cache folder, VRChat log directory, and optional Pushover credentials.
    The WinForms UI now mirrors the Linux layout with live **Status**, **Monitoring**, **Current Log**, **Session**, and **Last Event** indicators so you can see exactly what the watcher is doing.
    The first-run window defaults to a more compact size that keeps every control visible (even on high DPI desktops) and wraps long status text automatically, and the action buttons inherit the slimmer spacing used by the Linux port for a consistent look.

--- a/src/vrchat-join-notification-with-pushover.ps1
+++ b/src/vrchat-join-notification-with-pushover.ps1
@@ -1152,15 +1152,17 @@ function Get-LauncherPath {
 
 function Get-AppIcon {
     $candidates = @()
-    if($PSScriptRoot){
-        $candidates += Join-Path $PSScriptRoot $IconFileName
-        $candidates += Join-Path $PSScriptRoot ('vrchat_join_notification\' + $IconFileName)
+    $addCandidates = {
+        param([string]$BasePath)
+        if(-not $BasePath){ return }
+        $candidates += Join-Path $BasePath $IconFileName
+        $candidates += Join-Path (Join-Path $BasePath 'vrchat_join_notification') $IconFileName
+        $candidates += Join-Path (Join-Path $BasePath 'src') $IconFileName
+        $candidates += Join-Path (Join-Path (Join-Path $BasePath 'src') 'vrchat_join_notification') $IconFileName
     }
+    if($PSScriptRoot){ & $addCandidates $PSScriptRoot }
     $launcherDir = Split-Path (Get-LauncherPath) -Parent
-    if($launcherDir){
-        $candidates += Join-Path $launcherDir $IconFileName
-        $candidates += Join-Path $launcherDir ('vrchat_join_notification\' + $IconFileName)
-    }
+    if($launcherDir){ & $addCandidates $launcherDir }
     foreach($candidate in $candidates){
         if($candidate -and (Test-Path $candidate)){
             try { return New-Object System.Drawing.Icon($candidate) } catch {}


### PR DESCRIPTION
## Summary
- update the PowerShell tray icon loader to probe additional relative paths, including `src/notification.ico`, when running a packaged build
- document the new executable-side icon lookup so redistributors keep the `.ico` beside the compiled binary

## Testing
- not run (PowerShell script change only)


------
https://chatgpt.com/codex/tasks/task_e_68cb574ce864832c8c1e1f193a86c6ee