### PR TITLE
Tighten Windows settings UI, enforce single instance, and restore notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ A cross-platform helper that watches your VRChat logs and notifies you when play
 - Silently ignores the redundant generic desktop toast (`A player joined your instance.`) so only the richer, name-aware notification remains on Windows and Linux.
 - Debounces duplicate events with configurable cooldowns.
 - Optional Pushover integration in addition to local desktop notifications.
-- Simple tray-aware GUI on both Windows (PowerShell + WinForms) and Linux (Python + Tk + an optional system tray that disables itself automatically when prerequisites are missing). The Windows window now matches the Linux layout, including the live status fields.
+- Simple tray-aware GUI on both Windows (PowerShell + WinForms) and Linux (Python + Tk + an optional system tray that disables itself automatically when prerequisites are missing). The Windows window now matches the Linux layout, including the live status fields and compact spacing.
+- Windows builds guard against multiple launches and continue to raise desktop notifications (even when packaged as a `.exe`) by dispatching them through the UI thread.
 - Linux build offers one-click login startup integration that writes/removes the `.desktop` autostart entry for you and confirms the action with a desktop notification.
 
 ## Repository layout
@@ -52,7 +53,8 @@ cd vrchat-join-notification-with-pushover
    `vrchat_join_notification` subfolder variants), so keep the icon alongside the `.exe` when redistributing a packaged copy.
 3. Open **Settings** from the tray icon (or via the window) to configure the install/cache folder, VRChat log directory, and optional Pushover credentials.
    The WinForms UI now mirrors the Linux layout with live **Status**, **Monitoring**, **Current Log**, **Session**, and **Last Event** indicators so you can see exactly what the watcher is doing.
-   The first-run window defaults to a more compact size that keeps every control visible (even on high DPI desktops) and wraps long status text automatically, and the action buttons inherit the slimmer spacing used by the Linux port for a consistent look.
+   The first-run window defaults to a more compact size that keeps every control visible (even on high DPI desktops), trims the extra padding around each field, and wraps long status text automatically, while the action buttons inherit the slimmer spacing used by the Linux port for a consistent look.
+   Launching the packaged `.exe` while another copy is running now surfaces an informational dialog instead of starting a duplicate instance, and desktop notifications are marshalled onto the UI thread so Windows toasts fire reliably again.
 
 > [!NOTE]
 > The rewritten Windows script uses the same parsing and session logic as the Linux edition, including Unicode-safe string handling. All non-ASCII characters (Japanese log phrases, dash variants, etc.) are emitted explicitly so Windows PowerShell 5.1 and `ps2exe` builds remain reliable on localized systems.

--- a/src/vrchat-join-notification-with-pushover.ps1
+++ b/src/vrchat-join-notification-with-pushover.ps1
@@ -59,6 +59,8 @@ $script:Session = [ordered]@{
 }
 
 $script:Controls = @{}
+$script:SingleInstanceMutex = $null
+$script:HasMutexOwnership = $false
 
 # ----------------------------- Helper utils ------------------------------
 function Expand-PathSafe {
@@ -78,6 +80,35 @@ function Ensure-Dir {
     if(-not (Test-Path -Path $Path -PathType Container)){
         New-Item -Path $Path -ItemType Directory -Force | Out-Null
     }
+}
+
+function Acquire-SingleInstance {
+    Param([string]$Name)
+    if([string]::IsNullOrWhiteSpace($Name)){ return $true }
+    try {
+        $createdNew = $false
+        $script:SingleInstanceMutex = New-Object System.Threading.Mutex($true, $Name, [ref]$createdNew)
+        $script:HasMutexOwnership = $createdNew
+        return $createdNew
+    } catch {
+        $script:SingleInstanceMutex = $null
+        $script:HasMutexOwnership = $false
+        return $true
+    }
+}
+
+function Release-SingleInstance {
+    if(-not $script:SingleInstanceMutex){ return }
+    try {
+        if($script:HasMutexOwnership){
+            $script:SingleInstanceMutex.ReleaseMutex()
+        }
+    } catch {}
+    try {
+        $script:SingleInstanceMutex.Dispose()
+    } catch {}
+    $script:SingleInstanceMutex = $null
+    $script:HasMutexOwnership = $false
 }
 
 function Get-DefaultInstallDir {
@@ -198,6 +229,32 @@ function Enqueue-Event {
     $payload = [object[]]@($Type)
     if($Args){ $payload += $Args }
     $script:EventQueue.Enqueue($payload)
+}
+
+function Invoke-UIThread {
+    Param(
+        [Parameter(Mandatory=$true)][ScriptBlock]$Action,
+        [object[]]$Arguments
+    )
+    if(-not $Action){ return }
+    if(-not $Arguments){ $Arguments = @() }
+    $form = $null
+    if($script:Controls -and $script:Controls.ContainsKey('Form')){
+        $form = $script:Controls.Form
+    }
+    if($form -and -not $form.IsDisposed){
+        try {
+            if($form.InvokeRequired){
+                $form.BeginInvoke($Action, $Arguments) | Out-Null
+                return
+            }
+        } catch {}
+    }
+    if($Arguments.Length){
+        & $Action @Arguments
+    } else {
+        & $Action
+    }
 }
 
 function Strip-ZeroWidth {
@@ -788,14 +845,18 @@ function Handle-PlayerLeft {
 
 function Send-DesktopNotification {
     Param([string]$Title, [string]$Message)
-    if($script:TrayIcon){
+    if(-not $script:TrayIcon){ return }
+    $notifyAction = {
+        param($notifyTitle, $notifyMessage)
+        if(-not $script:TrayIcon){ return }
         try {
-            $script:TrayIcon.BalloonTipTitle = $Title
-            $script:TrayIcon.BalloonTipText = $Message
+            $script:TrayIcon.BalloonTipTitle = $notifyTitle
+            $script:TrayIcon.BalloonTipText = $notifyMessage
             $script:TrayIcon.BalloonTipIcon = [System.Windows.Forms.ToolTipIcon]::Info
             $script:TrayIcon.ShowBalloonTip(5000)
         } catch {}
-    }
+    }.GetNewClosure()
+    Invoke-UIThread -Action $notifyAction -Arguments @($Title, $Message)
 }
 
 function Send-PushoverNotification {
@@ -1315,12 +1376,13 @@ function Build-UI {
     $form.StartPosition = 'CenterScreen'
     $form.AutoScaleMode = [System.Windows.Forms.AutoScaleMode]::Font
     $form.AutoScaleDimensions = New-Object System.Drawing.SizeF(96, 96)
-    $form.ClientSize = New-Object System.Drawing.Size(720, 480)
-    $form.MinimumSize = New-Object System.Drawing.Size(640, 460)
+    $form.ClientSize = New-Object System.Drawing.Size(660, 420)
+    $form.MinimumSize = New-Object System.Drawing.Size(620, 400)
 
     $layout = New-Object System.Windows.Forms.TableLayoutPanel
     $layout.Dock = 'Fill'
-    $layout.Padding = New-Object System.Windows.Forms.Padding(12)
+    $layout.Margin = New-Object System.Windows.Forms.Padding(0)
+    $layout.Padding = New-Object System.Windows.Forms.Padding(10, 10, 10, 8)
     $layout.ColumnCount = 4
     $layout.RowCount = 6
     [void]$layout.ColumnStyles.Add((New-Object System.Windows.Forms.ColumnStyle([System.Windows.Forms.SizeType]::AutoSize)))
@@ -1335,17 +1397,20 @@ function Build-UI {
     $labelInstall = New-Object System.Windows.Forms.Label
     $labelInstall.Text = 'Install Folder (logs/cache):'
     $labelInstall.AutoSize = $true
+    $labelInstall.Margin = New-Object System.Windows.Forms.Padding(0, 0, 6, 4)
     $layout.Controls.Add($labelInstall, 0, 0)
 
     $installBox = New-Object System.Windows.Forms.TextBox
     $installBox.Text = $Config.InstallDir
     $installBox.Dock = 'Fill'
+    $installBox.Margin = New-Object System.Windows.Forms.Padding(0, 0, 3, 4)
     $layout.Controls.Add($installBox, 1, 0)
     [void]$layout.SetColumnSpan($installBox, 2)
 
     $browseInstall = New-Object System.Windows.Forms.Button
     $browseInstall.Text = 'Browse…'
     $browseInstall.AutoSize = $true
+    $browseInstall.Margin = New-Object System.Windows.Forms.Padding(3, 0, 0, 4)
     $layout.Controls.Add($browseInstall, 3, 0)
     $browseInstall.Add_Click({
         $dialog = New-Object System.Windows.Forms.FolderBrowserDialog
@@ -1358,17 +1423,20 @@ function Build-UI {
     $labelLog = New-Object System.Windows.Forms.Label
     $labelLog.Text = 'VRChat Log Folder:'
     $labelLog.AutoSize = $true
+    $labelLog.Margin = New-Object System.Windows.Forms.Padding(0, 0, 6, 4)
     $layout.Controls.Add($labelLog, 0, 1)
 
     $logBox = New-Object System.Windows.Forms.TextBox
     $logBox.Text = $Config.VRChatLogDir
     $logBox.Dock = 'Fill'
+    $logBox.Margin = New-Object System.Windows.Forms.Padding(0, 0, 3, 4)
     $layout.Controls.Add($logBox, 1, 1)
     [void]$layout.SetColumnSpan($logBox, 2)
 
     $browseLog = New-Object System.Windows.Forms.Button
     $browseLog.Text = 'Browse…'
     $browseLog.AutoSize = $true
+    $browseLog.Margin = New-Object System.Windows.Forms.Padding(3, 0, 0, 4)
     $layout.Controls.Add($browseLog, 3, 1)
     $browseLog.Add_Click({
         $dialog = New-Object System.Windows.Forms.FolderBrowserDialog
@@ -1381,11 +1449,13 @@ function Build-UI {
     $labelPO = New-Object System.Windows.Forms.Label
     $labelPO.Text = 'Pushover Credentials:'
     $labelPO.AutoSize = $true
+    $labelPO.Margin = New-Object System.Windows.Forms.Padding(0, 4, 6, 2)
     $layout.Controls.Add($labelPO, 0, 2)
 
     $poPanel = New-Object System.Windows.Forms.TableLayoutPanel
     $poPanel.ColumnCount = 4
     $poPanel.Dock = 'Fill'
+    $poPanel.Margin = New-Object System.Windows.Forms.Padding(0, 2, 0, 4)
     [void]$poPanel.ColumnStyles.Add((New-Object System.Windows.Forms.ColumnStyle([System.Windows.Forms.SizeType]::AutoSize)))
     [void]$poPanel.ColumnStyles.Add((New-Object System.Windows.Forms.ColumnStyle([System.Windows.Forms.SizeType]::Percent, 50)))
     [void]$poPanel.ColumnStyles.Add((New-Object System.Windows.Forms.ColumnStyle([System.Windows.Forms.SizeType]::AutoSize)))
@@ -1394,23 +1464,27 @@ function Build-UI {
     $poUserLabel = New-Object System.Windows.Forms.Label
     $poUserLabel.Text = 'User Key:'
     $poUserLabel.AutoSize = $true
+    $poUserLabel.Margin = New-Object System.Windows.Forms.Padding(0, 0, 6, 0)
     $poPanel.Controls.Add($poUserLabel, 0, 0)
 
     $poUserBox = New-Object System.Windows.Forms.TextBox
     $poUserBox.Text = $Config.PushoverUser
     $poUserBox.UseSystemPasswordChar = $true
     $poUserBox.Dock = 'Fill'
+    $poUserBox.Margin = New-Object System.Windows.Forms.Padding(0, 0, 6, 0)
     $poPanel.Controls.Add($poUserBox, 1, 0)
 
     $poTokenLabel = New-Object System.Windows.Forms.Label
     $poTokenLabel.Text = 'API Token:'
     $poTokenLabel.AutoSize = $true
+    $poTokenLabel.Margin = New-Object System.Windows.Forms.Padding(6, 0, 6, 0)
     $poPanel.Controls.Add($poTokenLabel, 2, 0)
 
     $poTokenBox = New-Object System.Windows.Forms.TextBox
     $poTokenBox.Text = $Config.PushoverToken
     $poTokenBox.UseSystemPasswordChar = $true
     $poTokenBox.Dock = 'Fill'
+    $poTokenBox.Margin = New-Object System.Windows.Forms.Padding(0, 0, 0, 0)
     $poPanel.Controls.Add($poTokenBox, 3, 0)
 
     $layout.Controls.Add($poPanel, 1, 2)
@@ -1421,7 +1495,8 @@ function Build-UI {
     $buttonPanel.Dock = 'Top'
     $buttonPanel.AutoSize = $true
     $buttonPanel.AutoSizeMode = 'GrowAndShrink'
-    $buttonPanel.Margin = New-Object System.Windows.Forms.Padding(0, 8, 0, 0)
+    $buttonPanel.Margin = New-Object System.Windows.Forms.Padding(0, 6, 0, 0)
+    $buttonPanel.Padding = New-Object System.Windows.Forms.Padding(0)
     $buttonPanel.RowCount = 1
     [void]$buttonPanel.RowStyles.Add((New-Object System.Windows.Forms.RowStyle([System.Windows.Forms.SizeType]::AutoSize)))
     foreach($i in 0..3){ [void]$buttonPanel.ColumnStyles.Add((New-Object System.Windows.Forms.ColumnStyle([System.Windows.Forms.SizeType]::Percent, 25))) }
@@ -1462,7 +1537,7 @@ function Build-UI {
     $extraPanel.Dock = 'Top'
     $extraPanel.AutoSize = $true
     $extraPanel.AutoSizeMode = 'GrowAndShrink'
-    $extraPanel.Margin = New-Object System.Windows.Forms.Padding(0, 6, 0, 0)
+    $extraPanel.Margin = New-Object System.Windows.Forms.Padding(0, 4, 0, 0)
     $extraPanel.RowCount = 1
     [void]$extraPanel.RowStyles.Add((New-Object System.Windows.Forms.RowStyle([System.Windows.Forms.SizeType]::AutoSize)))
     foreach($i in 0..3){ [void]$extraPanel.ColumnStyles.Add((New-Object System.Windows.Forms.ColumnStyle([System.Windows.Forms.SizeType]::Percent, 25))) }
@@ -1494,10 +1569,16 @@ function Build-UI {
     $statusGroup = New-Object System.Windows.Forms.GroupBox
     $statusGroup.Text = 'Status'
     $statusGroup.Dock = 'Fill'
+    $statusGroup.Margin = New-Object System.Windows.Forms.Padding(0, 8, 0, 0)
+    $statusGroup.Padding = New-Object System.Windows.Forms.Padding(10, 12, 10, 8)
 
     $statusTable = New-Object System.Windows.Forms.TableLayoutPanel
     $statusTable.Dock = 'Fill'
     $statusTable.ColumnCount = 2
+    $statusTable.AutoSize = $true
+    $statusTable.AutoSizeMode = 'GrowAndShrink'
+    $statusTable.Margin = New-Object System.Windows.Forms.Padding(0)
+    $statusTable.Padding = New-Object System.Windows.Forms.Padding(0, 2, 0, 0)
     [void]$statusTable.ColumnStyles.Add((New-Object System.Windows.Forms.ColumnStyle([System.Windows.Forms.SizeType]::AutoSize)))
     [void]$statusTable.ColumnStyles.Add((New-Object System.Windows.Forms.ColumnStyle([System.Windows.Forms.SizeType]::Percent, 100)))
 
@@ -1509,11 +1590,13 @@ function Build-UI {
         $label = New-Object System.Windows.Forms.Label
         $label.Text = $LabelText
         $label.AutoSize = $true
+        $label.Margin = New-Object System.Windows.Forms.Padding(0, 0, 6, 2)
         $Table.Controls.Add($label, 0, $row)
         $value = New-Object System.Windows.Forms.Label
         $value.Text = ''
         $value.AutoSize = $true
-        $value.MaximumSize = New-Object System.Drawing.Size(520, 0)
+        $value.Margin = New-Object System.Windows.Forms.Padding(0, 0, 0, 2)
+        $value.MaximumSize = New-Object System.Drawing.Size(500, 0)
         $Table.Controls.Add($value, 1, $row)
         return $value
     }
@@ -1641,4 +1724,15 @@ function Main {
     [System.Windows.Forms.Application]::Run($form)
 }
 
-Main
+$mutexName = 'Global\\VRChatJoinNotificationWithPushover'
+if(-not (Acquire-SingleInstance -Name $mutexName)){
+    [System.Windows.Forms.MessageBox]::Show("$AppName is already running.", $AppName, 'OK', 'Information') | Out-Null
+    Release-SingleInstance
+    return
+}
+
+try {
+    Main
+} finally {
+    Release-SingleInstance
+}


### PR DESCRIPTION
## Summary
- reduce excess padding/margins in the Windows WinForms layout so it matches the compact Linux presentation
- add a single-instance mutex guard for the Windows build so subsequent launches surface an informational dialog
- marshal desktop notifications through the UI thread to make compiled executables raise Windows toasts again and document the changes in the README

## Testing
- ⚠️ `pwsh` *(PowerShell is not available in the container to execute the Windows script)*

------
https://chatgpt.com/codex/tasks/task_e_68cb5968b790832ca673298ec7297127