### PR TITLE
Fix toast AppUserModel visibility warning

### DIFF
--- a/src/vrchat-join-notification-with-pushover.ps1
+++ b/src/vrchat-join-notification-with-pushover.ps1
@@ -21,7 +21,7 @@ if(-not ('NativeMethods.AppUserModel' -as [type])){
 using System;
 using System.Runtime.InteropServices;
 namespace NativeMethods {
-    internal static class AppUserModel {
+    public static class AppUserModel {
         [DllImport("shell32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern int SetCurrentProcessExplicitAppUserModelID(string appID);
     }


### PR DESCRIPTION
## Summary
- make the AppUserModel helper class public so the generated type is accessible when the script loads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb89003b10832c95be3fb37a646ddc