### PR TITLE
Fix AppUserModel interop visibility

### DIFF
--- a/src/vrchat-join-notification-with-pushover.ps1
+++ b/src/vrchat-join-notification-with-pushover.ps1
@@ -21,9 +21,9 @@ if(-not ('NativeMethods.AppUserModel' -as [type])){
 using System;
 using System.Runtime.InteropServices;
 namespace NativeMethods {
-    internal static class AppUserModel {
+    public static class AppUserModel {
         [DllImport("shell32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern int SetCurrentProcessExplicitAppUserModelID(string appID);
+        public static extern int SetCurrentProcessExplicitAppUserModelID(string appID);
     }
 }
 "@


### PR DESCRIPTION
## Summary
- make the AppUserModel interop wrapper public so the compiled executable can access it

## Testing
- not run (not applicable on this platform)


------
https://chatgpt.com/codex/tasks/task_e_68cbec0457c4832c8e5842d8f68d995e