### PR TITLE
Handle missing Runspace property in PowerShell

### DIFF
--- a/src/vrchat-join-notification-with-pushover.ps1
+++ b/src/vrchat-join-notification-with-pushover.ps1
@@ -135,7 +135,15 @@ $script:Controls = @{}
 $script:SingleInstanceMutex = $null
 $script:HasMutexOwnership = $false
 $script:AdditionalMutexes = @()
-$script:PrimaryRunspace = $ExecutionContext.Runspace
+$script:PrimaryRunspace = $null
+try {
+    if($ExecutionContext -and $ExecutionContext.PSObject.Properties.Match('Runspace').Count -gt 0){
+        $script:PrimaryRunspace = $ExecutionContext.Runspace
+    }
+} catch {}
+if(-not $script:PrimaryRunspace){
+    try { $script:PrimaryRunspace = [System.Management.Automation.Runspaces.Runspace]::DefaultRunspace } catch {}
+}
 
 # ----------------------------- Helper utils ------------------------------
 function Expand-PathSafe {


### PR DESCRIPTION
## Summary
- guard access to `$ExecutionContext.Runspace` and fall back to the default runspace so the script works on hosts without that property

## Testing
- not run (PowerShell script change only)


------
https://chatgpt.com/codex/tasks/task_e_68cc171f3d70832c8019c983d03db7d6