### PR TITLE
Fix Linux startup buttons method indentation

### DIFF
--- a/src/vrchat_join_notification/app.py
+++ b/src/vrchat_join_notification/app.py
@@ -1941,7 +1941,7 @@ class AppController:
         except Exception:
             return False
 
-def _update_startup_buttons(self) -> None:
+    def _update_startup_buttons(self) -> None:
         exists = self._autostart_entry_exists()
         if hasattr(self, "add_startup_button"):
             if exists:


### PR DESCRIPTION
## Summary
- move `_update_startup_buttons` back onto `AppController`
- ensure the startup buttons are updated correctly on Linux

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cc80865900832cb0bc4169960c0521