### PR TITLE
Prepare 0.1.1 release with corrected Linux docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ or build an executable (after importing the module):
    ```
 2. Install the app with your preferred tool:
    ```bash
-   python3 -m pip install --user '.[tray]'   # or omit [tray] if you do not need the system tray
+   python3 -m pip install --user 'vrchat-join-notification-with-pushover[tray]'   # or omit [tray] if you do not need the system tray
    # alternatively
-   pipx install '.[tray]'
+   pipx install 'vrchat-join-notification-with-pushover[tray]'
    ```
    If your distribution enforces an "externally managed" policy, append `--break-system-packages` or use a virtual environment.
 3. Launch the notifier:
@@ -64,13 +64,13 @@ or build an executable (after importing the module):
    ```
 2. Install the app. `pipx` keeps the CLI on your `$PATH` without touching system Python packages:
    ```bash
-   pipx install '.[tray]'
+   pipx install 'vrchat-join-notification-with-pushover[tray]'
    ```
    Garuda Linux uses the fish shell by default, so make sure `pipx`'s binary directory is exported once:
    ```fish
    set -Ux fish_user_paths $fish_user_paths ~/.local/bin
    ```
-   If you prefer `pip`, use `python -m pip install --user '.[tray]'` and ensure `~/.local/bin` is available in your shell.
+   If you prefer `pip`, use `python -m pip install --user 'vrchat-join-notification-with-pushover[tray]'` and ensure `~/.local/bin` is available in your shell.
 3. Run the notifier from any shell:
    ```bash
    vrchat-join-notifier
@@ -83,9 +83,9 @@ or build an executable (after importing the module):
    ```
 2. Install the app (with tray support when available):
    ```bash
-   python3 -m pip install --user '.[tray]'
+   python3 -m pip install --user 'vrchat-join-notification-with-pushover[tray]'
    # or
-   pipx install '.[tray]'
+   pipx install 'vrchat-join-notification-with-pushover[tray]'
    ```
 3. Launch the notifier:
    ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vrchat-join-notification-with-pushover"
-version = "0.1.0"
+version = "0.1.1"
 description = "Watch VRChat logs and send join notifications with optional Pushover pushes."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary
- bump the project version to 0.1.1 for the Linux startup fix release
- correct the Linux installation commands in the README to reference the published package name

## Testing
- PYTHONPATH=src python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cc857fcebc832cb9e29ce05cab46c9