### PR TITLE
Skip placeholder VRChat join pushes

### DIFF
--- a/src/vrchat_join_notification/app.py
+++ b/src/vrchat_join_notification/app.py
@@ -948,7 +948,13 @@ class SessionTracker:
         return True
 
     def notify_all(
-        self, key: str, title: str, message: str, *, desktop: bool = True
+        self,
+        key: str,
+        title: str,
+        message: str,
+        *,
+        desktop: bool = True,
+        pushover: bool = True,
     ) -> None:
         now = datetime.utcnow()
         previous = self.last_notified.get(key)
@@ -958,7 +964,8 @@ class SessionTracker:
         self.last_notified[key] = now
         if desktop:
             self.notifier.send(title, message)
-        self.pushover.send(title, message)
+        if pushover:
+            self.pushover.send(title, message)
 
     def handle_log_switch(self, path: str) -> None:
         self.logger.log(f"Switching to newest log: {path}")
@@ -1191,7 +1198,14 @@ class SessionTracker:
             if placeholder_lower == "a player":
                 desktop_notification = False
         message = f"{message_name} joined your instance."
-        self.notify_all(join_key, APP_NAME, message, desktop=desktop_notification)
+        pushover_notification = not was_placeholder
+        self.notify_all(
+            join_key,
+            APP_NAME,
+            message,
+            desktop=desktop_notification,
+            pushover=pushover_notification,
+        )
         log_line = f"Session {self.session_id}: player joined '{cleaned_name}'"
         if cleaned_user:
             log_line += f" ({cleaned_user})"


### PR DESCRIPTION
## Summary
- add a pushover flag to SessionTracker.notify_all so pushes can be disabled per event
- avoid sending pushover notifications for placeholder join events that lack a real player name

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cc8c67d1e8832caad068b99f61b5bc