### PR TITLE
Fix zero width regex for Go 1.25 compatibility

### DIFF
--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -26,7 +26,7 @@ var (
 	unicodeDashes       = "\u2013\u2014"
 	joinSeparatorChars  = ":|-" + unicodeDashes
 	joinSeparatorRegexp = regexp.MustCompile("[-:|" + unicodeDashes + "]+")
-	zeroWidthRegexp     = regexp.MustCompile("[\\u200b-\\u200d\\ufeff]")
+	zeroWidthRegexp     = regexp.MustCompile("[\u200B-\u200D\uFEFF]")
 	displayNameRegexp   = regexp.MustCompile(`(?i)displayName\s*[:=]\s*([^,\]\)]+)`)
 	nameRegexp          = regexp.MustCompile(`(?i)\bname\s*[:=]\s*([^,\]\)]+)`)
 	inlineUserIDRegexp  = regexp.MustCompile(`(?i)\(usr_[^\)\s]+\)`)


### PR DESCRIPTION
## Summary
- update the zero-width character regular expression to use literal runes instead of escaped sequences
- ensure the notifier can start without regex compilation panic on Go 1.25

## Testing
- go build ./cmd/vrchat-join-notification-with-pushover

------
https://chatgpt.com/codex/tasks/task_e_68ccab5347e4832c9ba976f9f083f7e0