### PR TITLE
Add non-CGO console fallback and refresh Windows packaging docs

### DIFF
--- a/FyneApp.toml
+++ b/FyneApp.toml
@@ -1,0 +1,4 @@
+appID = "com.vrchat.joinnotifier"
+name = "VRChat Join Notifier"
+icon = "src/notification.ico"
+version = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Cross-platform helper that watches VRChat logs and sends desktop and optional Pu
 ## Repository layout
 | Path | Description |
 | --- | --- |
-| `main.go` | Windows Go GUI entry point built with Fyne. |
+| `main.go` | Windows Go GUI entry point built with Fyne (requires CGO/OpenGL). |
+| `main_fallback.go` | Console-based entry point used when CGO is unavailable (e.g. Windows on ARM). |
 | `src/vrchat-join-notification-with-pushover_linux.py` | Legacy shim that calls the packaged Linux app. |
 | `src/vrchat_join_notification/` | Installable Python package with the Linux GUI and notifier logic. |
 | `go.mod` | Module definition for the Windows build. |
@@ -33,9 +34,9 @@ cd vrchat-join-notification-with-pushover
    ```powershell
    go version
    ```
-2. Install the Fyne CLI used for packaging:
+2. Install the maintained Fyne tooling used for packaging:
    ```powershell
-   go install fyne.io/fyne/v2/cmd/fyne@latest
+   go install fyne.io/tools/cmd/fyne@latest
    ```
    Ensure `%USERPROFILE%\go\bin` is on your `PATH` so the `fyne` command is available.
 3. Restore Go dependencies:
@@ -46,10 +47,11 @@ cd vrchat-join-notification-with-pushover
    ```powershell
    go build -ldflags="-H=windowsgui" -o VRChatJoinNotifier.exe .
    ```
+   > On Windows on ARM (or when CGO is disabled) the build automatically falls back to a console UI.
    > Cross-compiling from another platform? Prefix the command with `GOOS=windows GOARCH=amd64`.
 5. Package a distributable `.exe` with the embedded icon:
    ```powershell
-   fyne package -os windows -icon src/notification.ico -name VRChatJoinNotifier -release
+   fyne package -os windows -icon src/notification.ico -name VRChatJoinNotifier -appID com.vrchat.joinnotifier -release
    ```
    The packaged executable is written to `dist/VRChatJoinNotifier.exe`.
 6. Run `VRChatJoinNotifier.exe`, enter your **Pushover App Token** and **User Key**, and click **Save**.

--- a/main.go
+++ b/main.go
@@ -1,3 +1,5 @@
+//go:build cgo && !(windows && arm64)
+
 package main
 
 import (

--- a/main_fallback.go
+++ b/main_fallback.go
@@ -1,0 +1,167 @@
+//go:build !cgo || (windows && arm64)
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"vrchat-join-notification-with-pushover/internal/config"
+	"vrchat-join-notification-with-pushover/internal/logger"
+	"vrchat-join-notification-with-pushover/internal/logwatcher"
+	"vrchat-join-notification-with-pushover/internal/notify"
+	"vrchat-join-notification-with-pushover/internal/pushover"
+	"vrchat-join-notification-with-pushover/internal/session"
+)
+
+func main() {
+	fmt.Println("VRChat Join Notifier (console mode)")
+
+	cfg, err := config.Load()
+	if cfg == nil {
+		cfg = &config.Config{
+			InstallDir:   config.DefaultInstallDir(),
+			VRChatLogDir: config.GuessVRChatLogDir(),
+		}
+	}
+	if err != nil {
+		fmt.Printf("Configuration load warning: %v\n", err)
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	if updated := promptForConfiguration(reader, cfg); updated {
+		if err := cfg.Save(); err != nil {
+			fmt.Printf("Failed to save configuration: %v\n", err)
+		} else {
+			fmt.Printf("Configuration saved to %s\n", cfg.ConfigPath())
+		}
+	}
+
+	log := logger.New(cfg)
+	log.Log("Console mode activated. Press Ctrl+C to stop.")
+
+	events := make(chan logwatcher.Event, 128)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	monitor := logwatcher.New(cfg, log, events)
+	notifier := notify.New(log)
+	po := pushover.New(cfg, log)
+	tracker := session.New(notifier, po, log)
+
+	go monitor.Run(ctx)
+
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(signalCh)
+	go func() {
+		sig, ok := <-signalCh
+		if !ok {
+			return
+		}
+		log.Log(fmt.Sprintf("Received %s, shutting down...", sig))
+		cancel()
+	}()
+
+	for event := range events {
+		handleEvent(tracker, event)
+	}
+
+	log.Log("Monitor stopped.")
+}
+
+func promptForConfiguration(reader *bufio.Reader, cfg *config.Config) bool {
+	if reader == nil || cfg == nil {
+		return false
+	}
+
+	updated := false
+
+	token := strings.TrimSpace(cfg.PushoverToken)
+	if token == "" {
+		fmt.Print("Enter your Pushover App Token: ")
+		input, _ := reader.ReadString('\n')
+		token = strings.TrimSpace(input)
+		if token != "" {
+			cfg.PushoverToken = token
+			updated = true
+		}
+	}
+
+	user := strings.TrimSpace(cfg.PushoverUser)
+	if user == "" {
+		fmt.Print("Enter your Pushover User Key: ")
+		input, _ := reader.ReadString('\n')
+		user = strings.TrimSpace(input)
+		if user != "" {
+			cfg.PushoverUser = user
+			updated = true
+		}
+	}
+
+	dir := strings.TrimSpace(cfg.VRChatLogDir)
+	if dir == "" || !isDir(dir) {
+		if dir != "" {
+			fmt.Printf("VRChat log directory not found at %s.\n", dir)
+		}
+		fmt.Print("Enter the VRChat log directory path: ")
+		input, _ := reader.ReadString('\n')
+		dir = strings.TrimSpace(input)
+		if dir != "" {
+			cfg.VRChatLogDir = config.ExpandPath(dir)
+			updated = true
+		}
+	}
+
+	installDir := strings.TrimSpace(cfg.InstallDir)
+	if installDir == "" {
+		cfg.InstallDir = config.DefaultInstallDir()
+		updated = true
+	}
+
+	return updated
+}
+
+func handleEvent(tracker *session.Tracker, event logwatcher.Event) {
+	if tracker == nil {
+		return
+	}
+
+	switch event.Type {
+	case logwatcher.EventStatus:
+		tracker.HandleStatus(event.Message)
+	case logwatcher.EventError:
+		tracker.HandleError(event.Message)
+	case logwatcher.EventLogSwitch:
+		tracker.HandleLogSwitch(event.Path)
+	case logwatcher.EventRoomEnter:
+		tracker.HandleRoomEnter(event.Room)
+	case logwatcher.EventRoomLeft:
+		tracker.HandleRoomLeft()
+	case logwatcher.EventSelfJoin:
+		tracker.HandleSelfJoin(event.Raw)
+	case logwatcher.EventPlayerJoin:
+		tracker.HandlePlayerJoin(event.Player)
+	case logwatcher.EventPlayerLeft:
+		tracker.HandlePlayerLeft(event.Player)
+	}
+}
+
+func isDir(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if !filepath.IsAbs(path) {
+			info, err = os.Stat(config.ExpandPath(path))
+		}
+	}
+	return err == nil && info.IsDir()
+}


### PR DESCRIPTION
## Summary
- add a console-mode entry point that activates when CGO is unavailable or on Windows/ARM64 builds
- gate the existing Fyne GUI behind a CGO/non-Windows-ARM64 build tag so standard builds remain unchanged
- document the fallback in the README, switch packaging instructions to the new fyne tool, add the required appID flag, and check in FyneApp.toml metadata

## Testing
- not run (Go module proxy is blocked in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ccbb52e784832c8a0d1d7d9838cecf