### PR TITLE
Fix Windows console fallback startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ cd vrchat-join-notification-with-pushover
    ```powershell
    go build -ldflags="-H=windowsgui" -o VRChatJoinNotifier.exe .
    ```
-   > On Windows on ARM (or when CGO is disabled) the build automatically falls back to a console UI.
+   > On Windows on ARM (or when CGO is disabled) the build automatically falls back to a console UI and spawns its own console window when launched from Explorer.
    > Cross-compiling from another platform? Prefix the command with `GOOS=windows GOARCH=amd64`.
 5. Package a distributable `.exe` with the embedded icon:
    ```powershell
-   fyne package -os windows -icon src/notification.ico -name VRChatJoinNotifier -appID com.vrchat.joinnotifier -release
+   fyne package -os windows -icon src/notification.ico -name VRChatJoinNotifier --app-id com.vrchat.joinnotifier -release
    ```
    The packaged executable is written to `dist/VRChatJoinNotifier.exe`.
 6. Run `VRChatJoinNotifier.exe`, enter your **Pushover App Token** and **User Key**, and click **Save**.

--- a/console_stub.go
+++ b/console_stub.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package main
+
+func ensureConsole() {}

--- a/console_windows.go
+++ b/console_windows.go
@@ -1,0 +1,78 @@
+//go:build windows && (!cgo || arm64)
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+const attachParentProcess = ^uint32(0)
+
+var (
+	kernel32             = syscall.NewLazyDLL("kernel32.dll")
+	procAttachConsole    = kernel32.NewProc("AttachConsole")
+	procAllocConsole     = kernel32.NewProc("AllocConsole")
+	procSetConsoleCtrl   = kernel32.NewProc("SetConsoleCtrlHandler")
+	procFreeConsole      = kernel32.NewProc("FreeConsole")
+	procGetConsoleWindow = kernel32.NewProc("GetConsoleWindow")
+)
+
+// ensureConsole attaches to a parent console or allocates a new one when the
+// fallback CLI is built as a GUI executable.
+func ensureConsole() {
+	if hasConsole() {
+		return
+	}
+	if !attachConsole() && !allocConsole() {
+		return
+	}
+	redirectStdHandles()
+}
+
+func hasConsole() bool {
+	if hwnd, _, _ := procGetConsoleWindow.Call(); hwnd != 0 {
+		return true
+	}
+	handle, err := syscall.GetStdHandle(syscall.STD_OUTPUT_HANDLE)
+	if err != nil {
+		return false
+	}
+	return handle != 0 && handle != syscall.InvalidHandle
+}
+
+func attachConsole() bool {
+	r, _, _ := procAttachConsole.Call(uintptr(attachParentProcess))
+	return r != 0
+}
+
+func allocConsole() bool {
+	r, _, _ := procAllocConsole.Call()
+	return r != 0
+}
+
+func redirectStdHandles() {
+	// Disable the default CTRL handlers so closing the console does not
+	// terminate the process unexpectedly.
+	procSetConsoleCtrl.Call(0, 1)
+
+	if h, err := syscall.GetStdHandle(syscall.STD_INPUT_HANDLE); err == nil && h != 0 && h != syscall.InvalidHandle {
+		if f := os.NewFile(uintptr(h), "CONIN$"); f != nil {
+			os.Stdin = f
+		}
+	}
+	if h, err := syscall.GetStdHandle(syscall.STD_OUTPUT_HANDLE); err == nil && h != 0 && h != syscall.InvalidHandle {
+		if f := os.NewFile(uintptr(h), "CONOUT$"); f != nil {
+			os.Stdout = f
+		}
+	}
+	if h, err := syscall.GetStdHandle(syscall.STD_ERROR_HANDLE); err == nil && h != 0 && h != syscall.InvalidHandle {
+		if f := os.NewFile(uintptr(h), "CONOUT$"); f != nil {
+			os.Stderr = f
+		}
+	}
+}
+
+func releaseConsole() {
+	procFreeConsole.Call()
+}

--- a/main_fallback.go
+++ b/main_fallback.go
@@ -21,6 +21,8 @@ import (
 )
 
 func main() {
+	ensureConsole()
+
 	fmt.Println("VRChat Join Notifier (console mode)")
 
 	cfg, err := config.Load()


### PR DESCRIPTION
## Summary
- ensure the Windows fallback entry point allocates or attaches to a console before prompting
- add a Windows-specific helper that reattaches standard handles when running without a console
- correct the README packaging flag and note the automatic console window for non-CGO builds

## Testing
- go test ./internal/...

------
https://chatgpt.com/codex/tasks/task_e_68ccbe5f550c832c9d74e4c6a373063d