### PR TITLE
Update Windows default storage directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ With the virtual environment active you can launch the GUI directly:
 python -m vrchat_join_notification.app
 ```
 
-> Configuration files and logs now default to `%LOCALAPPDATA%\vrchat-join-notification-with-pushover`. Update the **Install Dir** in-app if you prefer to store assets elsewhere on Windows.
+> Configuration files and logs now default to `%LOCALAPPDATA%\VRChatJoinNotificationWithPushover`. Update the **Install Dir** in-app if you prefer to store assets elsewhere on Windows.
 
 ### 4. Package with PyInstaller
 Bundle the Python build into a single-file `.exe` when you want to redistribute it.

--- a/src/vrchat_join_notification/app.py
+++ b/src/vrchat_join_notification/app.py
@@ -69,7 +69,7 @@ def _expand_path(path: str) -> str:
 def _default_storage_root() -> str:
     if os.name == "nt":
         root = os.path.join(
-            _windows_local_appdata(), "vrchat-join-notification-with-pushover"
+            _windows_local_appdata(), "VRChatJoinNotificationWithPushover"
         )
     else:
         root = os.path.join(
@@ -82,6 +82,9 @@ def _legacy_storage_roots() -> Tuple[str, ...]:
     candidates: list[str] = []
     if os.name == "nt":
         local_appdata = _windows_local_appdata()
+        candidates.append(
+            os.path.join(local_appdata, "vrchat-join-notification-with-pushover")
+        )
         candidates.append(os.path.join(local_appdata, "VRChatJoinNotifier"))
         appdata = os.environ.get("APPDATA")
         if appdata:


### PR DESCRIPTION
## Summary
- update the Windows default storage directory to `%LOCALAPPDATA%\VRChatJoinNotificationWithPushover`
- retain the previous hyphenated directory as a legacy search path for existing installs
- document the new default path in the README

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cd07ca0e7c832c9854d54f889df1b2