### PR TITLE
Hide transient PowerShell window for Windows toast notifications

### DIFF
--- a/src/vrchat_join_notification/app.py
+++ b/src/vrchat_join_notification/app.py
@@ -832,11 +832,17 @@ class DesktopNotifier:
                 startupinfo.wShowWindow = getattr(subprocess, "SW_HIDE", 0)
         creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
         try:
+            creationflags |= getattr(subprocess, "DETACHED_PROCESS", 0)
+        except AttributeError:
+            pass
+        try:
             result = subprocess.run(
                 [
                     self._powershell,
                     "-NoProfile",
                     "-NonInteractive",
+                    "-WindowStyle",
+                    "Hidden",
                     "-ExecutionPolicy",
                     "Bypass",
                     "-EncodedCommand",


### PR DESCRIPTION
## Summary
- ensure the PowerShell process that sends Windows toast notifications launches fully hidden
- add the `-WindowStyle Hidden` flag and use detached process startup flags when invoking PowerShell

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cd242aa064832c89b9ade938385a2c