### PR TITLE
Encrypt Pushover credentials in config file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ classifiers = [
   "Topic :: Games/Entertainment",
   "Topic :: System :: Monitoring",
 ]
-dependencies = []
+dependencies = [
+  "cryptography>=41",
+]
 
 [project.optional-dependencies]
 tray = [


### PR DESCRIPTION
## Summary
- add a cryptography dependency so the app can protect stored Pushover credentials
- generate and reuse a per-installation encryption key to save the user and API tokens as encrypted strings
- decrypt encrypted secrets on load while surfacing helpful error messages if the key is missing or invalid

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cd25e2a368832caa0319f0d7aa5937