### PR TITLE
Improve Windows build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,23 @@ Resident desktop companion that watches your VRChat logs and pings you on the de
    python -m pip install --upgrade pip
    python -m pip install .           # add '.[tray]' for the optional tray icon
    ```
+   Planning to bundle a Windows executable? Install PyInstaller alongside the project:
+   ```powershell
+   python -m pip install pyinstaller
+   ```
 4. **Run it**
    ```bash
    vrchat-join-notifier
    # or
    python -m vrchat_join_notification.app
    ```
+
+5. **(Optional) Build a Windows executable**
+   ```powershell
+   .\tools\build-windows-exe.ps1
+   ```
+   The script drops a portable `.exe` in `dist/`. If you need to run PyInstaller yourself in PowerShell, quote the `--add-data`
+   flag so the semicolon separator is preserved: `--add-data "src/vrchat_join_notification/notification.ico;vrchat_join_notification"`.
 
 ### Linux prerequisites
 Install Python, Tk, and `libnotify` before running the steps above.
@@ -73,7 +84,7 @@ If you prefer a standalone `.exe`, clone the repository on Windows and compile i
    # equivalent manual command
    pyinstaller --noconsole --name VRChatJoinNotificationWithPushover `
        --icon src/vrchat_join_notification/notification.ico `
-       --add-data src/vrchat_join_notification/notification.ico;vrchat_join_notification `
+       --add-data "src/vrchat_join_notification/notification.ico;vrchat_join_notification" `
        src/vrchat_join_notification/app.py
    ```
    After the run completes you will find `VRChatJoinNotificationWithPushover.exe` in `dist/` ready for distribution.


### PR DESCRIPTION
## Summary
- document how to install PyInstaller during quick setup when targeting a Windows executable
- add an optional quick-install step for creating the bundled EXE and highlight the need to quote --add-data in PowerShell
- correct the manual PyInstaller example to use the quoted --add-data flag so it works in PowerShell

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd4a2d4978832cb23eefafd6fc000e