### PR TITLE
Add Go-based Windows tray companion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VRChat Join Notification with Pushover
 
-Resident desktop companion that watches your VRChat logs and pings you on the desktop (and optionally through Pushover) whenever a friend joins your instance. The GUI is built with Tkinter, so everything can be configured in-app.
+Resident desktop companion that watches your VRChat logs and pings you on the desktop (and optionally through Pushover) whenever a friend joins your instance. The original release ships a Python/Tkinter GUI, and the repository now additionally contains a native Go-based tray companion for Windows with a self-contained settings window.
 
 ## Highlights
 - Tracks VRChat sessions safely, suppressing duplicates and ignoring your own joins.
@@ -8,6 +8,34 @@ Resident desktop companion that watches your VRChat logs and pings you on the de
 - Optional system tray with quick start/stop controls when `pystray` and `Pillow` are installed.
 
 ## Quick install from source
+
+### Windows native tray companion (Go)
+
+Prefer a small self-contained `.exe` with a built-in settings UI and task-tray controls? Compile the Go implementation that lives in `cmd/vrchat-notifier`.
+
+**Prerequisites**
+
+- Windows 10/11.
+- [Go 1.21 or newer](https://go.dev/dl/).
+
+**Build & run**
+
+1. **Clone the repository**
+   ```powershell
+   git clone https://github.com/yueplush/vrchat-join-notification-with-pushover.git
+   Set-Location vrchat-join-notification-with-pushover
+   ```
+2. **Compile the tray application**
+   ```powershell
+   go build -o bin/vrchat-notifier.exe ./cmd/vrchat-notifier
+   ```
+   The build embeds no external assets – just ensure `notification.ico` sits next to the executable (it is already present in the repository root).
+3. **Launch the watcher**
+   ```powershell
+   .\bin\vrchat-notifier.exe
+   ```
+
+The Go binary stores configuration files in `%LOCALAPPDATA%\VRChatJoinNotificationWithPushover`, mirroring the Python application's layout. A system-tray icon exposes quick commands (Open Settings, Start/Stop/Restart Monitoring and Quit) and the window may be re-opened at any time from the tray. Desktop notifications and Pushover integration behave just like the original implementation.
 
 ### Windows (PowerShell)
 

--- a/cmd/vrchat-notifier/main_windows.go
+++ b/cmd/vrchat-notifier/main_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"vrchat-join-notification-with-pushover/internal/app"
+)
+
+func main() {
+	guard, err := app.AcquireSingleInstance("VRChatJoinNotificationWithPushover")
+	if err != nil {
+		if errors.Is(err, app.ErrAlreadyRunning) {
+			app.ShowMessage(err.Error(), app.AppName, app.MBOK|app.MBIconWarning)
+			return
+		}
+		app.ShowMessage(fmt.Sprintf("Failed to acquire single instance lock:\n%v", err), app.AppName, app.MBOK|app.MBIconError)
+		return
+	}
+	defer guard.Release()
+
+	cfg, loadNotice, err := app.LoadConfig()
+	if err != nil {
+		app.ShowMessage(fmt.Sprintf("Failed to load configuration:\n%v", err), app.AppName, app.MBOK|app.MBIconError)
+		return
+	}
+	logger := app.NewAppLogger(cfg)
+	logger.Log("Application started.")
+	if loadNotice != "" {
+		logger.Log(loadNotice)
+	}
+
+	controller, err := app.NewController(cfg, loadNotice, logger)
+	if err != nil {
+		app.ShowMessage(fmt.Sprintf("Failed to initialise UI:\n%v", err), app.AppName, app.MBOK|app.MBIconError)
+		return
+	}
+
+	if err := controller.Run(); err != nil {
+		logger.Logf("Application exited with error: %v", err)
+	} else {
+		logger.Log("Application exited cleanly.")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module vrchat-join-notification-with-pushover
+
+go 1.24.3

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -1,0 +1,369 @@
+package app
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	configFileName  = "config.json"
+	pointerFileName = "config-location.txt"
+	appLogName      = "notifier.log"
+)
+
+// AppConfig mirrors the JSON configuration used by the original Python
+// implementation. It stores persistent settings such as the installation
+// directory, the VRChat log directory and optional Pushover credentials.
+type AppConfig struct {
+	InstallDir    string
+	VRChatLogDir  string
+	PushoverUser  string
+	PushoverToken string
+	FirstRun      bool
+}
+
+// LoadConfig restores the configuration from disk. It returns the populated
+// configuration instance together with an optional warning string describing
+// non fatal load issues.
+func LoadConfig() (*AppConfig, string, error) {
+	storageRoot := defaultStorageRoot()
+	if err := os.MkdirAll(storageRoot, 0o755); err != nil {
+		return nil, "", fmt.Errorf("create storage root: %w", err)
+	}
+
+	installDir := storageRoot
+	pointerCandidates := []string{filepath.Join(storageRoot, pointerFileName)}
+	for _, legacy := range legacyStorageRoots() {
+		if legacy != storageRoot {
+			pointerCandidates = append(pointerCandidates, filepath.Join(legacy, pointerFileName))
+		}
+	}
+	for _, candidate := range pointerCandidates {
+		data, err := os.ReadFile(candidate)
+		if err != nil {
+			continue
+		}
+		resolved := expandPath(strings.TrimSpace(string(data)))
+		if stat, err := os.Stat(resolved); err == nil && stat.IsDir() {
+			installDir = resolved
+			break
+		}
+	}
+
+	configPath := filepath.Join(installDir, configFileName)
+	fallbackPath := filepath.Join(storageRoot, configFileName)
+
+	configExists := fileExists(configPath)
+	fallbackExists := fileExists(fallbackPath)
+
+	if !configExists && !fallbackExists {
+		for _, legacy := range legacyStorageRoots() {
+			legacyConfig := filepath.Join(legacy, configFileName)
+			if fileExists(legacyConfig) {
+				installDir = legacy
+				configPath = legacyConfig
+				configExists = true
+				break
+			}
+		}
+	}
+
+	payload := map[string]string{}
+	firstRun := !(configExists || fallbackExists)
+	var loadWarning string
+
+	if configExists {
+		if err := loadConfigFile(configPath, payload); err != nil {
+			loadWarning = err.Error()
+			payload = map[string]string{}
+		}
+	} else if installDir != storageRoot && fallbackExists {
+		if err := loadConfigFile(fallbackPath, payload); err != nil {
+			loadWarning = err.Error()
+			payload = map[string]string{}
+		} else {
+			installDir = storageRoot
+		}
+	}
+
+	cfg := &AppConfig{
+		InstallDir:    expandPath(valueOr(payload, "InstallDir", installDir)),
+		VRChatLogDir:  expandPath(valueOr(payload, "VRChatLogDir", guessVRChatLogDir())),
+		PushoverUser:  strings.TrimSpace(valueOr(payload, "PushoverUser", "")),
+		PushoverToken: strings.TrimSpace(valueOr(payload, "PushoverToken", "")),
+		FirstRun:      firstRun,
+	}
+
+	legacyRoots := legacyStorageRoots()
+	if len(legacyRoots) > 0 {
+		primaryLegacy := filepath.Clean(legacyRoots[0])
+		if filepath.Clean(cfg.InstallDir) == primaryLegacy && primaryLegacy != filepath.Clean(storageRoot) {
+			newConfig := filepath.Join(storageRoot, configFileName)
+			if fileExists(newConfig) {
+				cfg.InstallDir = storageRoot
+			} else {
+				original := cfg.InstallDir
+				cfg.InstallDir = storageRoot
+				if err := cfg.Save(); err != nil {
+					cfg.InstallDir = original
+				}
+			}
+		}
+	}
+
+	if err := cfg.EnsureInstallDir(); err != nil {
+		return nil, "", err
+	}
+	_ = cfg.writePointer()
+
+	return cfg, loadWarning, nil
+}
+
+func (c *AppConfig) ConfigPath() string {
+	return filepath.Join(c.InstallDir, configFileName)
+}
+
+func (c *AppConfig) EnsureInstallDir() error {
+	if c.InstallDir == "" {
+		return errors.New("install directory is empty")
+	}
+	return os.MkdirAll(c.InstallDir, 0o755)
+}
+
+func (c *AppConfig) Save() error {
+	if err := c.EnsureInstallDir(); err != nil {
+		return err
+	}
+	payload := map[string]string{
+		"InstallDir":   expandPath(c.InstallDir),
+		"VRChatLogDir": expandPath(c.VRChatLogDir),
+	}
+	if strings.TrimSpace(c.PushoverUser) != "" {
+		payload["PushoverUser"] = strings.TrimSpace(c.PushoverUser)
+	}
+	if strings.TrimSpace(c.PushoverToken) != "" {
+		payload["PushoverToken"] = strings.TrimSpace(c.PushoverToken)
+	}
+
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode config: %w", err)
+	}
+	if err := os.WriteFile(c.ConfigPath(), data, 0o644); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+	if err := c.writePointer(); err != nil {
+		return err
+	}
+	c.FirstRun = false
+	return nil
+}
+
+func (c *AppConfig) writePointer() error {
+	storageRoot := defaultStorageRoot()
+	if err := os.MkdirAll(storageRoot, 0o755); err != nil {
+		return err
+	}
+	pointerPath := filepath.Join(storageRoot, pointerFileName)
+	return os.WriteFile(pointerPath, []byte(expandPath(c.InstallDir)), 0o644)
+}
+
+func loadConfigFile(path string, payload map[string]string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to load settings: %w", err)
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("failed to parse settings: %w", err)
+	}
+	for key, value := range raw {
+		switch v := value.(type) {
+		case string:
+			payload[key] = v
+		case fmt.Stringer:
+			payload[key] = v.String()
+		default:
+			payload[key] = fmt.Sprintf("%v", v)
+		}
+	}
+	return nil
+}
+
+func valueOr(m map[string]string, key, fallback string) string {
+	if v, ok := m[key]; ok && strings.TrimSpace(v) != "" {
+		return v
+	}
+	return fallback
+}
+
+func expandPath(path string) string {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return ""
+	}
+	expanded := os.ExpandEnv(trimmed)
+	if strings.HasPrefix(expanded, "~") {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			expanded = filepath.Join(home, strings.TrimPrefix(expanded, "~"))
+		}
+	}
+	if abs, err := filepath.Abs(expanded); err == nil {
+		return abs
+	}
+	return filepath.Clean(expanded)
+}
+
+func fileExists(path string) bool {
+	if path == "" {
+		return false
+	}
+	if stat, err := os.Stat(path); err == nil {
+		return !stat.IsDir()
+	}
+	return false
+}
+
+func directoryExists(path string) bool {
+	if path == "" {
+		return false
+	}
+	if stat, err := os.Stat(path); err == nil {
+		return stat.IsDir()
+	}
+	return false
+}
+
+func defaultStorageRoot() string {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(windowsLocalAppData(), "VRChatJoinNotificationWithPushover")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".local", "share", "vrchat-join-notification-with-pushover")
+}
+
+func legacyStorageRoots() []string {
+	var roots []string
+	if runtime.GOOS == "windows" {
+		localAppData := windowsLocalAppData()
+		roots = append(roots,
+			filepath.Join(localAppData, "vrchat-join-notification-with-pushover"),
+			filepath.Join(localAppData, "VRChatJoinNotifier"),
+		)
+		if appdata := os.Getenv("APPDATA"); appdata != "" {
+			roots = append(roots, expandPath(filepath.Join(appdata, "VRChatJoinNotifier")))
+		}
+		home, err := os.UserHomeDir()
+		if err == nil {
+			roots = append(roots, filepath.Join(home, ".local", "share", "vrchat-join-notification-with-pushover"))
+		}
+	} else {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			roots = append(roots, filepath.Join(home, ".local", "share", "VRChatJoinNotifier"))
+		}
+	}
+	dedupe := map[string]struct{}{}
+	var result []string
+	for _, root := range roots {
+		resolved := expandPath(root)
+		if _, ok := dedupe[resolved]; ok {
+			continue
+		}
+		dedupe[resolved] = struct{}{}
+		result = append(result, resolved)
+	}
+	return result
+}
+
+func windowsLocalAppData() string {
+	if v := os.Getenv("LOCALAPPDATA"); v != "" {
+		return expandPath(v)
+	}
+	profile := os.Getenv("USERPROFILE")
+	if profile == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			profile = home
+		}
+	}
+	if profile == "" {
+		return ""
+	}
+	return expandPath(filepath.Join(profile, "AppData", "Local"))
+}
+
+func windowsLocalLowDir() string {
+	candidates := []string{}
+	if local := os.Getenv("LOCALAPPDATA"); local != "" {
+		candidates = append(candidates, filepath.Join(local, "..", "LocalLow"))
+	}
+	if profile := os.Getenv("USERPROFILE"); profile != "" {
+		candidates = append(candidates, filepath.Join(profile, "AppData", "LocalLow"))
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates, filepath.Join(home, "AppData", "LocalLow"))
+	}
+	for _, candidate := range candidates {
+		resolved := expandPath(candidate)
+		if directoryExists(resolved) {
+			return resolved
+		}
+	}
+	if len(candidates) > 0 {
+		return expandPath(candidates[0])
+	}
+	return ""
+}
+
+func guessVRChatLogDir() string {
+	if runtime.GOOS == "windows" {
+		base := windowsLocalLowDir()
+		if base == "" {
+			return ""
+		}
+		candidates := []string{
+			filepath.Join(base, "VRChat", "VRChat"),
+		}
+		for _, candidate := range candidates {
+			resolved := expandPath(candidate)
+			if directoryExists(resolved) {
+				return resolved
+			}
+		}
+		if len(candidates) > 0 {
+			return expandPath(candidates[0])
+		}
+		return ""
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	candidates := []string{
+		filepath.Join(home, ".steam", "steam", "steamapps", "compatdata", "438100", "pfx", "drive_c", "users", "steamuser", "AppData", "LocalLow", "VRChat", "VRChat"),
+		filepath.Join(home, ".local", "share", "Steam", "steamapps", "compatdata", "438100", "pfx", "drive_c", "users", "steamuser", "AppData", "LocalLow", "VRChat", "VRChat"),
+	}
+	for _, candidate := range candidates {
+		resolved := expandPath(candidate)
+		if directoryExists(resolved) {
+			return resolved
+		}
+	}
+	if len(candidates) > 0 {
+		return expandPath(candidates[0])
+	}
+	return ""
+}
+
+func AppLogPath(cfg *AppConfig) string {
+	return filepath.Join(cfg.InstallDir, appLogName)
+}

--- a/internal/app/constants.go
+++ b/internal/app/constants.go
@@ -1,0 +1,9 @@
+package app
+
+const (
+    AppName       = "VRChat Join Notification with Pushover"
+    IconFileName  = "notification.ico"
+    PoURL         = "https://api.pushover.net/1/messages.json"
+    NotifyCooldownSeconds = 10
+)
+

--- a/internal/app/guard_windows.go
+++ b/internal/app/guard_windows.go
@@ -1,0 +1,49 @@
+//go:build windows
+
+package app
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+)
+
+// ErrAlreadyRunning indicates that another copy of the application is already
+// holding the single-instance mutex.
+var ErrAlreadyRunning = errors.New(AppName + " is already running.")
+
+// InstanceGuard prevents multiple copies of the notifier from running at the
+// same time by relying on a named Windows mutex.
+type InstanceGuard struct {
+	handle syscall.Handle
+	name   string
+}
+
+// AcquireSingleInstance attempts to create the named mutex. When another copy
+// is already running it returns ErrAlreadyRunning.
+func AcquireSingleInstance(name string) (*InstanceGuard, error) {
+	if name == "" {
+		name = "VRChatJoinNotificationWithPushover"
+	}
+	handle, errno := createNamedMutex(name)
+	if errno != 0 {
+		if errno == syscall.ERROR_ALREADY_EXISTS {
+			closeHandle(handle)
+			return nil, ErrAlreadyRunning
+		}
+		return nil, fmt.Errorf("create mutex: %w", errno)
+	}
+	return &InstanceGuard{handle: handle, name: name}, nil
+}
+
+// Release frees the underlying mutex handle.
+func (g *InstanceGuard) Release() {
+	if g == nil {
+		return
+	}
+	if g.handle != 0 {
+		releaseMutex(g.handle)
+		closeHandle(g.handle)
+		g.handle = 0
+	}
+}

--- a/internal/app/logger.go
+++ b/internal/app/logger.go
@@ -1,0 +1,73 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// AppLogger appends timestamped log messages to notifier.log inside the
+// installation directory. Logging is deliberately best-effort so that failures
+// never interrupt monitoring behaviour.
+type AppLogger struct {
+	cfg *AppConfig
+	mu  sync.Mutex
+}
+
+func NewAppLogger(cfg *AppConfig) *AppLogger {
+	return &AppLogger{cfg: cfg}
+}
+
+func (l *AppLogger) Log(message string) {
+	if l == nil || l.cfg == nil {
+		return
+	}
+	if err := l.cfg.EnsureInstallDir(); err != nil {
+		return
+	}
+	path := AppLogPath(l.cfg)
+	if path == "" {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	line := fmt.Sprintf("[%s] %s\n", time.Now().Format("2006-01-02 15:04:05"), message)
+	_, _ = f.WriteString(line)
+}
+
+// Logf formats according to a format specifier and logs the resulting message.
+func (l *AppLogger) Logf(format string, args ...interface{}) {
+	l.Log(fmt.Sprintf(format, args...))
+}
+
+// OpenLogDirectory best-effort opens the installation directory using the
+// default Windows file explorer.
+func (l *AppLogger) OpenLogDirectory() {
+	if l == nil || l.cfg == nil {
+		return
+	}
+	path := l.cfg.InstallDir
+	if path == "" {
+		return
+	}
+	// Only attempt to launch explorer on Windows. The binary itself is
+	// Windows-only, but guarding it keeps go vet and static analysis quiet when
+	// building on other systems for testing.
+	explorer, err := exec.LookPath("explorer.exe")
+	if err != nil {
+		return
+	}
+	proc, err := os.StartProcess(explorer, []string{"explorer.exe", filepath.Clean(path)}, &os.ProcAttr{})
+	if err != nil {
+		return
+	}
+	_ = proc.Release()
+}

--- a/internal/app/messagebox_windows.go
+++ b/internal/app/messagebox_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package app
+
+// Message box flag aliases for callers outside the package.
+const (
+	MBOK          = mbOK
+	MBIconInfo    = mbIconInformation
+	MBIconWarning = mbIconWarning
+	MBIconError   = mbIconError
+)
+
+// ShowMessage displays a modal Windows message box.
+func ShowMessage(text, title string, flags uint32) {
+	messageBox(0, text, title, flags)
+}

--- a/internal/app/monitor.go
+++ b/internal/app/monitor.go
@@ -1,0 +1,294 @@
+package app
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+type MonitorEventType string
+
+const (
+	EventStatus     MonitorEventType = "status"
+	EventLogSwitch  MonitorEventType = "log_switch"
+	EventError      MonitorEventType = "error"
+	EventRoomEnter  MonitorEventType = "room_enter"
+	EventRoomLeft   MonitorEventType = "room_left"
+	EventSelfJoin   MonitorEventType = "self_join"
+	EventPlayerJoin MonitorEventType = "player_join"
+	EventPlayerLeft MonitorEventType = "player_left"
+)
+
+type MonitorEvent struct {
+	Type    MonitorEventType
+	Message string
+	Room    RoomEvent
+	Player  PlayerEvent
+	Path    string
+}
+
+// LogMonitor tails the VRChat log files and emits parsed events to the GUI.
+type LogMonitor struct {
+	cfg    *AppConfig
+	logger *AppLogger
+	events chan<- MonitorEvent
+
+	stopOnce sync.Once
+	stopCh   chan struct{}
+	doneCh   chan struct{}
+}
+
+func NewLogMonitor(cfg *AppConfig, logger *AppLogger, events chan<- MonitorEvent) *LogMonitor {
+	return &LogMonitor{
+		cfg:    cfg,
+		logger: logger,
+		events: events,
+		stopCh: make(chan struct{}),
+		doneCh: make(chan struct{}),
+	}
+}
+
+func (m *LogMonitor) Start() {
+	go m.run()
+}
+
+func (m *LogMonitor) Stop() {
+	m.stopOnce.Do(func() {
+		close(m.stopCh)
+	})
+	select {
+	case <-m.doneCh:
+	case <-time.After(2 * time.Second):
+	}
+}
+
+func (m *LogMonitor) emit(event MonitorEvent) {
+	select {
+	case <-m.stopCh:
+		return
+	case m.events <- event:
+	}
+}
+
+var (
+	behaviourSelfRegex  = regexp.MustCompile(`(?i)\[Behaviour\].*OnJoinedRoom\b`)
+	behaviourJoinRegex  = regexp.MustCompile(`(?i)\[Behaviour\].*OnPlayerJoined\b`)
+	behaviourLeaveRegex = regexp.MustCompile(`(?i)\[Behaviour\].*OnPlayerLeft\b`)
+)
+
+func (m *LogMonitor) run() {
+	defer close(m.doneCh)
+	var lastDirWarning time.Time
+	var lastNoFileWarning time.Time
+	for {
+		select {
+		case <-m.stopCh:
+			return
+		default:
+		}
+		logDir := strings.TrimSpace(m.cfg.VRChatLogDir)
+		if logDir == "" || !directoryExists(logDir) {
+			if time.Since(lastDirWarning) > 10*time.Second {
+				m.emit(MonitorEvent{Type: EventStatus, Message: "Waiting for VRChat log directory at " + logDir})
+				lastDirWarning = time.Now()
+			}
+			if m.waitForStop(1 * time.Second) {
+				return
+			}
+			continue
+		}
+		newest := getNewestLogPath(logDir)
+		if newest == "" {
+			if time.Since(lastNoFileWarning) > 10*time.Second {
+				m.emit(MonitorEvent{Type: EventStatus, Message: "No log files found in " + logDir})
+				lastNoFileWarning = time.Now()
+			}
+			if m.waitForStop(1 * time.Second) {
+				return
+			}
+			continue
+		}
+		if m.followFile(newest, logDir) {
+			return
+		}
+	}
+}
+
+func (m *LogMonitor) waitForStop(d time.Duration) bool {
+	select {
+	case <-m.stopCh:
+		return true
+	case <-time.After(d):
+		return false
+	}
+}
+
+func (m *LogMonitor) followFile(path string, logDir string) bool {
+	normalized := filepath.Clean(path)
+	m.emit(MonitorEvent{Type: EventLogSwitch, Path: normalized})
+	var lastSize int64
+	if info, err := os.Stat(normalized); err == nil {
+		lastSize = info.Size()
+	}
+	for {
+		select {
+		case <-m.stopCh:
+			return true
+		default:
+		}
+		file, err := os.Open(normalized)
+		if err != nil {
+			if m.logger != nil {
+				m.logger.Logf("Failed reading log '%s': %v", normalized, err)
+			}
+			m.emit(MonitorEvent{Type: EventError, Message: "Log read error: " + err.Error()})
+			if m.waitForStop(2 * time.Second) {
+				return true
+			}
+			continue
+		}
+		reader := bufio.NewReader(file)
+		if _, err := file.Seek(lastSize, io.SeekStart); err != nil {
+			lastSize = 0
+			file.Seek(0, io.SeekStart)
+		}
+		for {
+			select {
+			case <-m.stopCh:
+				file.Close()
+				return true
+			default:
+			}
+			position, _ := file.Seek(0, io.SeekCurrent)
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					if m.waitForStop(600 * time.Millisecond) {
+						file.Close()
+						return true
+					}
+					info, statErr := os.Stat(normalized)
+					if statErr != nil {
+						file.Close()
+						time.Sleep(600 * time.Millisecond)
+						break
+					}
+					if info.Size() < lastSize {
+						lastSize = 0
+						file.Seek(0, io.SeekStart)
+						reader.Reset(file)
+						continue
+					}
+					newest := getNewestLogPath(logDir)
+					if newest != "" && filepath.Clean(newest) != normalized {
+						file.Close()
+						return false
+					}
+					file.Seek(position, io.SeekStart)
+					reader.Reset(file)
+					continue
+				}
+				file.Close()
+				if m.logger != nil {
+					m.logger.Logf("Failed reading log '%s': %v", normalized, err)
+				}
+				m.emit(MonitorEvent{Type: EventError, Message: "Log read error: " + err.Error()})
+				if m.waitForStop(2 * time.Second) {
+					return true
+				}
+				break
+			}
+			lastSize += int64(len(line))
+			trimmed := strings.TrimRight(line, "\r\n")
+			m.processLine(trimmed)
+		}
+		file.Close()
+	}
+}
+
+func (m *LogMonitor) processLine(line string) {
+	if strings.TrimSpace(line) == "" {
+		return
+	}
+	safeLine := strings.ReplaceAll(stripZeroWidth(line), "||", "|")
+	lowerLine := strings.ToLower(safeLine)
+	if strings.Contains(lowerLine, "onleftroom") {
+		m.emit(MonitorEvent{Type: EventRoomLeft, Message: safeLine})
+		return
+	}
+	if room, ok := parseRoomTransitionLine(safeLine); ok {
+		m.emit(MonitorEvent{Type: EventRoomEnter, Room: room})
+		return
+	}
+	if behaviourSelfRegex.MatchString(safeLine) {
+		m.emit(MonitorEvent{Type: EventSelfJoin, Message: safeLine})
+		return
+	}
+	if behaviourLeaveRegex.MatchString(safeLine) {
+		if player, ok := parsePlayerEventLine(safeLine, "OnPlayerLeft"); ok {
+			m.emit(MonitorEvent{Type: EventPlayerLeft, Player: player})
+		} else {
+			m.emit(MonitorEvent{Type: EventPlayerLeft, Player: PlayerEvent{RawLine: safeLine}})
+		}
+		return
+	}
+	if behaviourJoinRegex.MatchString(safeLine) {
+		if player, ok := parsePlayerEventLine(safeLine, "OnPlayerJoined"); ok {
+			m.emit(MonitorEvent{Type: EventPlayerJoin, Player: player})
+		} else {
+			m.emit(MonitorEvent{Type: EventPlayerJoin, Player: PlayerEvent{RawLine: safeLine}})
+		}
+		return
+	}
+}
+
+var logTimestampPattern = regexp.MustCompile(`(?i)output_log_([0-9]{4})-([0-9]{2})-([0-9]{2})_([0-9]{2})-([0-9]{2})-([0-9]{2})`)
+
+func getNewestLogPath(logDir string) string {
+	entries, err := os.ReadDir(logDir)
+	if err != nil {
+		return ""
+	}
+	var bestPath string
+	var bestScore float64
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := strings.ToLower(entry.Name())
+		if name == "player.log" || strings.HasPrefix(name, "output_log_") {
+			path := filepath.Join(logDir, entry.Name())
+			score := scoreLogFile(path)
+			if score > bestScore {
+				bestScore = score
+				bestPath = path
+			}
+		}
+	}
+	return bestPath
+}
+
+func scoreLogFile(path string) float64 {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	best := float64(info.ModTime().Unix())
+	if matches := logTimestampPattern.FindStringSubmatch(strings.ToLower(filepath.Base(path))); len(matches) == 7 {
+		layout := "2006-01-02 15:04:05"
+		candidate := fmt.Sprintf("%s-%s-%s %s:%s:%s", matches[1], matches[2], matches[3], matches[4], matches[5], matches[6])
+		if t, err := time.ParseInLocation(layout, candidate, time.Local); err == nil {
+			if float64(t.Unix()) > best {
+				best = float64(t.Unix())
+			}
+		}
+	}
+	return best
+}

--- a/internal/app/notifier.go
+++ b/internal/app/notifier.go
@@ -1,0 +1,180 @@
+package app
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"strings"
+	"syscall"
+	"unicode/utf16"
+)
+
+// DesktopNotifier triggers local notifications. On Windows it uses PowerShell to
+// display modern toast notifications, mirroring the behaviour of the Python
+// implementation.
+type DesktopNotifier struct {
+	logger     *AppLogger
+	powershell string
+}
+
+func NewDesktopNotifier(logger *AppLogger) *DesktopNotifier {
+	return &DesktopNotifier{
+		logger:     logger,
+		powershell: findPowerShell(),
+	}
+}
+
+// Send dispatches the notification asynchronously so the UI remains responsive.
+func (n *DesktopNotifier) Send(title, message string) {
+	if n == nil {
+		return
+	}
+	go n.sendInternal(title, message)
+}
+
+func (n *DesktopNotifier) sendInternal(title, message string) {
+	if runtime.GOOS == "windows" && n.sendWindowsToast(title, message) {
+		return
+	}
+	if n.logger != nil {
+		n.logger.Logf("Notification: %s - %s", title, message)
+	}
+}
+
+func (n *DesktopNotifier) sendWindowsToast(title, message string) bool {
+	if n.powershell == "" {
+		return false
+	}
+	script := buildWindowsToastScript(title, message)
+	utf16Script := utf16.Encode([]rune(script))
+	buf := bytes.NewBuffer(nil)
+	for _, code := range utf16Script {
+		_ = binary.Write(buf, binary.LittleEndian, code)
+	}
+	encoded := base64.StdEncoding.EncodeToString(buf.Bytes())
+	cmd := exec.Command(n.powershell, "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-EncodedCommand", encoded)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	if err := cmd.Run(); err != nil {
+		if n.logger != nil {
+			n.logger.Logf("PowerShell toast error: %v", err)
+		}
+		return false
+	}
+	return true
+}
+
+func buildWindowsToastScript(title, message string) string {
+	safeTitle := title
+	if strings.TrimSpace(safeTitle) == "" {
+		safeTitle = AppName
+	}
+	safeMessage := message
+	script := `
+$Title = %s
+$Message = %s
+[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
+[Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom.XmlDocument, ContentType = WindowsRuntime] | Out-Null
+$Template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02)
+$TextNodes = $Template.GetElementsByTagName("text")
+if ($TextNodes.Count -gt 0) { $TextNodes.Item(0).AppendChild($Template.CreateTextNode($Title)) | Out-Null }
+if ($TextNodes.Count -gt 1) { $TextNodes.Item(1).AppendChild($Template.CreateTextNode($Message)) | Out-Null }
+$Toast = [Windows.UI.Notifications.ToastNotification]::new($Template)
+$Toast.Tag = "vrchat-join"
+$Toast.Group = "vrchat-join"
+$Notifier = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier(%s)
+$Notifier.Show($Toast)
+`
+	return fmtSprintf(script, jsonString(safeTitle), jsonString(safeMessage), jsonString(AppName))
+}
+
+func fmtSprintf(format string, args ...interface{}) string {
+	return strings.TrimSpace(fmt.Sprintf(format, args...))
+}
+
+func jsonString(value string) string {
+	data, _ := json.Marshal(value)
+	return string(data)
+}
+
+func findPowerShell() string {
+	candidates := []string{"powershell.exe", "pwsh.exe", "powershell", "pwsh"}
+	for _, candidate := range candidates {
+		if path, err := exec.LookPath(candidate); err == nil {
+			return path
+		}
+	}
+	return ""
+}
+
+// PushoverClient performs HTTPS requests against the Pushover API when the user
+// supplied API token and user key are present in the configuration.
+type PushoverClient struct {
+	cfg    *AppConfig
+	logger *AppLogger
+}
+
+func NewPushoverClient(cfg *AppConfig, logger *AppLogger) *PushoverClient {
+	return &PushoverClient{cfg: cfg, logger: logger}
+}
+
+// Send transmits the push notification asynchronously.
+func (p *PushoverClient) Send(title, message string) {
+	if p == nil || p.cfg == nil {
+		return
+	}
+	token := strings.TrimSpace(p.cfg.PushoverToken)
+	user := strings.TrimSpace(p.cfg.PushoverUser)
+	if token == "" || user == "" {
+		if p.logger != nil {
+			p.logger.Log("Pushover not configured; skipping.")
+		}
+		return
+	}
+	go p.sendInternal(token, user, title, message)
+}
+
+func (p *PushoverClient) sendInternal(token, user, title, message string) {
+	payload := url.Values{
+		"token":    {token},
+		"user":     {user},
+		"title":    {title},
+		"message":  {message},
+		"priority": {"0"},
+	}
+	resp, err := http.PostForm(PoURL, payload)
+	if err != nil {
+		if p.logger != nil {
+			p.logger.Logf("Pushover error: %v", err)
+		}
+		return
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if p.logger == nil {
+		return
+	}
+	var parsed struct {
+		Status int      `json:"status"`
+		Errors []string `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		p.logger.Log("Pushover sent; response parsing failed.")
+		return
+	}
+	if parsed.Status == 1 {
+		p.logger.Log("Pushover sent: 1")
+	} else if len(parsed.Errors) > 0 {
+		p.logger.Logf("Pushover rejected: %s", strings.Join(parsed.Errors, "; "))
+	} else {
+		p.logger.Logf("Pushover responded with status %d", parsed.Status)
+	}
+}

--- a/internal/app/session.go
+++ b/internal/app/session.go
@@ -1,0 +1,602 @@
+package app
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+	"unicode/utf8"
+)
+
+type RoomEvent struct {
+	World    string
+	Instance string
+	RawLine  string
+}
+
+type PlayerEvent struct {
+	Name        string
+	UserID      string
+	Placeholder string
+	RawLine     string
+}
+
+var (
+	zeroWidthPattern      = regexp.MustCompile(`[\u200b-\u200d\ufeff]`)
+	joinSeparatorPattern  = regexp.MustCompile(`^[-:|\u2013\u2014]+$`)
+	displayNamePattern    = regexp.MustCompile(`(?i)displayName\s*[:=]\s*([^,\]\)]+)`)
+	namePattern           = regexp.MustCompile(`(?i)\bname\s*[:=]\s*([^,\]\)]+)`)
+	userIDParenPattern    = regexp.MustCompile(`(?i)\(usr_[^\)\s]+\)`)
+	userIDAssignment      = regexp.MustCompile(`(?i)userId\s*[:=]\s*(usr_[0-9a-f\-]+)`)
+	cleanupUserIDPattern  = regexp.MustCompile(`(?i)\(usr_[^\)]*\)`)
+	cleanupUserRawPattern = regexp.MustCompile(`(?i)\(userId[^\)]*\)`)
+	cleanupBracketPattern = regexp.MustCompile(`\[[^\]]*\]`)
+	cleanupBracePattern   = regexp.MustCompile(`\{[^\}]*\}`)
+	cleanupAnglePattern   = regexp.MustCompile(`<[^>]*>`)
+	roomWorldPattern      = regexp.MustCompile(`(?i)wrld_[0-9a-f\-]+`)
+	markerPattern         = regexp.MustCompile(`(?i)\b(displayName|name|userId)\b`)
+)
+
+const (
+	unicodeDashes      = "\u2013\u2014"
+	joinSeparatorChars = ":|-" + unicodeDashes
+	sessionCooldown    = time.Duration(NotifyCooldownSeconds) * time.Second
+)
+
+// SessionTracker mirrors the behaviour of the Python implementation but is
+// intentionally pragmatic: it focuses on reliable notifications and log output
+// rather than re-implementing every legacy edge case.
+type SessionTracker struct {
+	notifier *DesktopNotifier
+	pushover *PushoverClient
+	logger   *AppLogger
+
+	mu                sync.Mutex
+	sessionID         int
+	ready             bool
+	source            string
+	seenPlayers       map[string]time.Time
+	lastNotified      map[string]time.Time
+	pendingRoom       *RoomEvent
+	sessionStartedAt  time.Time
+	sessionLastJoinAt time.Time
+	lastJoinRaw       string
+	localUserID       string
+	lastEvent         string
+}
+
+func NewSessionTracker(n *DesktopNotifier, p *PushoverClient, logger *AppLogger) *SessionTracker {
+	return &SessionTracker{
+		notifier:     n,
+		pushover:     p,
+		logger:       logger,
+		seenPlayers:  make(map[string]time.Time),
+		lastNotified: make(map[string]time.Time),
+	}
+}
+
+func (s *SessionTracker) Reset(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ready = false
+	s.source = ""
+	s.pendingRoom = nil
+	s.sessionStartedAt = time.Time{}
+	s.sessionLastJoinAt = time.Time{}
+	s.lastJoinRaw = ""
+	s.seenPlayers = make(map[string]time.Time)
+	s.localUserID = ""
+	s.lastEvent = ""
+	if reason != "" && s.logger != nil {
+		s.logger.Log(reason)
+	}
+}
+
+func (s *SessionTracker) HandleLogSwitch(path string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ready = false
+	s.source = ""
+	s.pendingRoom = nil
+	s.sessionStartedAt = time.Time{}
+	s.sessionLastJoinAt = time.Time{}
+	s.lastJoinRaw = ""
+	s.seenPlayers = make(map[string]time.Time)
+	s.localUserID = ""
+	s.lastEvent = ""
+	message := fmt.Sprintf("Switching to newest log: %s", path)
+	if s.logger != nil {
+		s.logger.Log(message)
+	}
+	return message
+}
+
+func (s *SessionTracker) HandleRoomEnter(event RoomEvent) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pendingRoom = &event
+	var desc string
+	if event.World != "" {
+		desc = event.World
+		if event.Instance != "" {
+			desc += ":" + event.Instance
+		}
+	} else if event.RawLine != "" {
+		desc = event.RawLine
+	}
+	if desc == "" {
+		desc = "Room transition detected."
+	} else {
+		desc = "Room transition detected: " + desc
+	}
+	s.lastEvent = desc
+	if s.logger != nil {
+		s.logger.Log(desc)
+	}
+	return desc
+}
+
+func (s *SessionTracker) HandleRoomLeft() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var message string
+	if s.ready {
+		message = fmt.Sprintf("Session %d ended (OnLeftRoom detected.)", s.sessionID)
+	} else {
+		message = "OnLeftRoom detected."
+	}
+	s.ready = false
+	s.source = ""
+	s.pendingRoom = nil
+	s.seenPlayers = make(map[string]time.Time)
+	s.lastEvent = message
+	if s.logger != nil {
+		s.logger.Log(message)
+	}
+	return message
+}
+
+func (s *SessionTracker) HandleSelfJoin(rawLine string) string {
+	if runtime.GOOS == "windows" && !isVRChatRunning() {
+		if s.logger != nil {
+			s.logger.Log("Ignored self join while VRChat is not running.")
+		}
+		return ""
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.ensureSessionReadyLocked("OnJoinedRoom detected") {
+		if s.logger != nil {
+			s.logger.Log(fmt.Sprintf("Session %d started (OnJoinedRoom detected.)", s.sessionID))
+		}
+	}
+	s.lastJoinRaw = rawLine
+	s.lastEvent = "OnJoinedRoom"
+	return ""
+}
+
+func (s *SessionTracker) HandlePlayerJoin(event PlayerEvent) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ensureSessionReadyLocked("OnPlayerJoined fallback")
+	cleanedName := normalizeJoinName(event.Name)
+	cleanedUser := strings.TrimSpace(event.UserID)
+	wasPlaceholder := isPlaceholderName(cleanedName)
+	if wasPlaceholder && cleanedUser != "" {
+		if s.localUserID != "" && strings.EqualFold(s.localUserID, cleanedUser) {
+			wasPlaceholder = false
+			cleanedName = cleanedUser
+		} else {
+			cleanedName = cleanedUser
+			wasPlaceholder = false
+		}
+	}
+	if cleanedName == "" && cleanedUser != "" {
+		cleanedName = cleanedUser
+		wasPlaceholder = false
+	}
+	if cleanedName == "" {
+		cleanedName = "Unknown VRChat user"
+	}
+	keyBase := strings.ToLower(cleanedUser)
+	if keyBase == "" {
+		keyBase = strings.ToLower(cleanedName)
+	}
+	hashSuffix := ""
+	if keyBase == "" {
+		hashSuffix = getShortHash(event.RawLine)
+		keyBase = hashSuffix
+	}
+	joinKey := fmt.Sprintf("join:%d:%s", s.sessionID, keyBase)
+	if hashSuffix != "" {
+		joinKey += ":" + hashSuffix
+	}
+	if _, exists := s.seenPlayers[joinKey]; exists {
+		return ""
+	}
+	s.seenPlayers[joinKey] = time.Now()
+	placeholderName := normalizeJoinName(event.Placeholder)
+	if placeholderName == "" && wasPlaceholder {
+		placeholderName = event.Name
+	}
+	if placeholderName == "" {
+		placeholderName = "Someone"
+	}
+	messageName := cleanedName
+	if messageName == "" {
+		messageName = placeholderName
+	}
+	message := fmt.Sprintf("%s joined your instance.", messageName)
+	desktopNotification := true
+	if wasPlaceholder && cleanedUser == "" {
+		lowerPlaceholder := strings.TrimSpace(strings.ToLower(placeholderName))
+		if lowerPlaceholder == "a player" {
+			desktopNotification = false
+		}
+	}
+	pushoverNotification := !wasPlaceholder
+	s.notifyAll(joinKey, AppName, message, desktopNotification, pushoverNotification)
+	if s.logger != nil {
+		logLine := fmt.Sprintf("Session %d: player joined '%s'", s.sessionID, messageName)
+		if cleanedUser != "" {
+			logLine += fmt.Sprintf(" (%s)", cleanedUser)
+		}
+		logLine += "."
+		s.logger.Log(logLine)
+	}
+	s.sessionLastJoinAt = time.Now()
+	s.lastJoinRaw = event.RawLine
+	s.lastEvent = message
+	return message
+}
+
+func (s *SessionTracker) HandlePlayerLeft(event PlayerEvent) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cleanedName := normalizeJoinName(event.Name)
+	cleanedUser := strings.TrimSpace(event.UserID)
+	if cleanedName == "" && cleanedUser != "" {
+		cleanedName = cleanedUser
+	}
+	if cleanedName == "" {
+		cleanedName = "Unknown VRChat user"
+	}
+	if cleanedUser != "" {
+		s.localUserID = cleanedUser
+		prefix := fmt.Sprintf("join:%d:%s", s.sessionID, strings.ToLower(cleanedUser))
+		for key := range s.seenPlayers {
+			if strings.HasPrefix(key, prefix) {
+				delete(s.seenPlayers, key)
+			}
+		}
+	}
+	if s.logger != nil {
+		logLine := fmt.Sprintf("Session %d: player left '%s'", s.sessionID, cleanedName)
+		if cleanedUser != "" {
+			logLine += fmt.Sprintf(" (%s)", cleanedUser)
+		}
+		logLine += "."
+		s.logger.Log(logLine)
+	}
+	s.lastEvent = fmt.Sprintf("%s left the instance.", cleanedName)
+	return cleanedName
+}
+
+func (s *SessionTracker) ensureSessionReadyLocked(reason string) bool {
+	if s.ready {
+		return false
+	}
+	if strings.TrimSpace(reason) == "" {
+		reason = "unknown trigger"
+	}
+	s.sessionID++
+	s.ready = true
+	s.source = reason
+	s.seenPlayers = make(map[string]time.Time)
+	s.sessionStartedAt = time.Now()
+	s.sessionLastJoinAt = time.Time{}
+	s.lastJoinRaw = ""
+	var roomDesc string
+	if s.pendingRoom != nil {
+		if s.pendingRoom.World != "" {
+			roomDesc = s.pendingRoom.World
+			if s.pendingRoom.Instance != "" {
+				roomDesc += ":" + s.pendingRoom.Instance
+			}
+		} else if s.pendingRoom.RawLine != "" {
+			roomDesc = s.pendingRoom.RawLine
+		}
+	}
+	message := fmt.Sprintf("Session %d started (%s)", s.sessionID, reason)
+	if roomDesc != "" {
+		message += fmt.Sprintf(" [%s]", roomDesc)
+	}
+	message += "."
+	if s.logger != nil {
+		s.logger.Log(message)
+	}
+	s.lastEvent = message
+	return true
+}
+
+func (s *SessionTracker) notifyAll(key, title, message string, desktop, push bool) {
+	now := time.Now()
+	if previous, ok := s.lastNotified[key]; ok {
+		if now.Sub(previous) < sessionCooldown {
+			if s.logger != nil {
+				s.logger.Logf("Suppressed '%s' within cooldown.", key)
+			}
+			return
+		}
+	}
+	s.lastNotified[key] = now
+	if desktop && s.notifier != nil {
+		s.notifier.Send(title, message)
+	}
+	if push && s.pushover != nil {
+		s.pushover.Send(title, message)
+	}
+}
+
+func (s *SessionTracker) Summary() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.ready {
+		return "No active session"
+	}
+	desc := fmt.Sprintf("Session %d (%s)", s.sessionID, s.source)
+	if s.pendingRoom != nil {
+		var room string
+		if s.pendingRoom.World != "" {
+			room = s.pendingRoom.World
+			if s.pendingRoom.Instance != "" {
+				room += ":" + s.pendingRoom.Instance
+			}
+		} else if s.pendingRoom.RawLine != "" {
+			room = s.pendingRoom.RawLine
+		}
+		if room != "" {
+			desc += " [" + room + "]"
+		}
+	}
+	return desc
+}
+
+func (s *SessionTracker) LastEvent() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastEvent
+}
+
+func stripZeroWidth(text string) string {
+	return zeroWidthPattern.ReplaceAllString(text, "")
+}
+
+func normalizeJoinFragment(text string) string {
+	clean := stripZeroWidth(text)
+	clean = strings.ReplaceAll(clean, "\u3000", " ")
+	clean = strings.TrimSpace(strings.Trim(strings.Trim(clean, "\""), "'"))
+	clean = strings.ReplaceAll(clean, "||", "|")
+	clean = strings.TrimLeft(clean, joinSeparatorChars)
+	clean = strings.TrimSpace(clean)
+	if len(clean) > 160 {
+		clean = strings.TrimSpace(clean[:160])
+	}
+	if joinSeparatorPattern.MatchString(clean) {
+		return ""
+	}
+	return clean
+}
+
+func normalizeJoinName(name string) string {
+	return normalizeJoinFragment(name)
+}
+
+func isPlaceholderName(name string) bool {
+	if strings.TrimSpace(name) == "" {
+		return true
+	}
+	trimmed := strings.ToLower(strings.TrimSpace(name))
+	switch trimmed {
+	case "player", "you", "someone", "a player":
+		return true
+	default:
+		return false
+	}
+}
+
+func getShortHash(text string) string {
+	if strings.TrimSpace(text) == "" {
+		return ""
+	}
+	sum := md5.Sum([]byte(text))
+	hexed := hex.EncodeToString(sum[:])
+	if len(hexed) > 8 {
+		return hexed[:8]
+	}
+	return hexed
+}
+
+func parsePlayerEventLine(line string, eventToken string) (PlayerEvent, bool) {
+	if strings.TrimSpace(line) == "" {
+		return PlayerEvent{}, false
+	}
+	lower := strings.ToLower(line)
+	needle := strings.ToLower(eventToken)
+	idx := strings.Index(lower, needle)
+	if idx < 0 {
+		return PlayerEvent{}, false
+	}
+	after := stripZeroWidth(line[idx+len(eventToken):])
+	after = strings.TrimSpace(after)
+	for len(after) > 0 {
+		r, size := utf8.DecodeRuneInString(after)
+		if strings.ContainsRune(joinSeparatorChars, r) {
+			after = strings.TrimSpace(after[size:])
+			continue
+		}
+		break
+	}
+	placeholder := ""
+	if after != "" {
+		candidate := after
+		if loc := markerPattern.FindStringIndex(after); loc != nil {
+			candidate = candidate[:loc[0]]
+		}
+		for _, cut := range []string{"(", "[", "{", "<"} {
+			if idx := strings.Index(candidate, cut); idx >= 0 {
+				candidate = candidate[:idx]
+			}
+		}
+		candidate = normalizeJoinFragment(candidate)
+		if isPlaceholderName(candidate) {
+			placeholder = candidate
+		}
+	}
+	displayName := ""
+	if match := displayNamePattern.FindStringSubmatch(after); len(match) > 1 {
+		displayName = normalizeJoinFragment(match[1])
+	}
+	if displayName == "" {
+		if match := namePattern.FindStringSubmatch(after); len(match) > 1 {
+			displayName = normalizeJoinFragment(match[1])
+		}
+	}
+	userID := ""
+	if match := userIDParenPattern.FindString(after); match != "" {
+		userID = strings.Trim(match, "() ")
+	}
+	if userID == "" {
+		if match := userIDAssignment.FindStringSubmatch(after); len(match) > 1 {
+			userID = strings.TrimSpace(match[1])
+		}
+	}
+	if displayName == "" {
+		tmp := after
+		if userID != "" {
+			tmp = strings.ReplaceAll(tmp, "("+userID+")", "")
+		}
+		tmp = cleanupUserIDPattern.ReplaceAllString(tmp, "")
+		tmp = cleanupUserRawPattern.ReplaceAllString(tmp, "")
+		tmp = cleanupBracketPattern.ReplaceAllString(tmp, "")
+		tmp = cleanupBracePattern.ReplaceAllString(tmp, "")
+		tmp = cleanupAnglePattern.ReplaceAllString(tmp, "")
+		tmp = strings.ReplaceAll(tmp, "||", "|")
+		displayName = normalizeJoinFragment(tmp)
+	}
+	if displayName == "" && userID != "" {
+		displayName = userID
+	}
+	safeLine := strings.TrimSpace(strings.ReplaceAll(stripZeroWidth(line), "||", "|"))
+	return PlayerEvent{
+		Name:        displayName,
+		UserID:      userID,
+		Placeholder: placeholder,
+		RawLine:     safeLine,
+	}, true
+}
+
+func parseRoomTransitionLine(line string) (RoomEvent, bool) {
+	clean := strings.TrimSpace(stripZeroWidth(line))
+	if clean == "" {
+		return RoomEvent{}, false
+	}
+	lower := strings.ToLower(clean)
+	indicators := []string{
+		"joining or creating room",
+		"entering room",
+		"joining room",
+		"creating room",
+		"created room",
+		"rejoining room",
+		"re-joining room",
+		"reentering room",
+		"re-entering room",
+		"joining instance",
+		"creating instance",
+		"entering instance",
+	}
+	matched := false
+	for _, indicator := range indicators {
+		if strings.Contains(lower, indicator) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		jpSets := []struct {
+			Key   string
+			Terms []string
+		}{
+			{Key: "ルーム", Terms: []string{"参加", "作成", "入室", "移動", "入場"}},
+			{Key: "インスタンス", Terms: []string{"参加", "作成", "入室", "移動", "入場"}},
+		}
+		for _, jp := range jpSets {
+			if strings.Contains(clean, jp.Key) {
+				for _, term := range jp.Terms {
+					if strings.Contains(clean, term) {
+						matched = true
+						break
+					}
+				}
+			}
+			if matched {
+				break
+			}
+		}
+	}
+	if !matched {
+		if roomWorldPattern.MatchString(clean) {
+			if strings.Contains(lower, "room") || strings.Contains(lower, "instance") ||
+				strings.Contains(clean, "インスタンス") || strings.Contains(clean, "ルーム") {
+				matched = true
+			}
+		}
+	}
+	if !matched {
+		return RoomEvent{}, false
+	}
+	world := ""
+	instance := ""
+	if match := roomWorldPattern.FindStringIndex(clean); match != nil {
+		world = clean[match[0]:match[1]]
+		after := strings.TrimSpace(clean[match[1]:])
+		after = strings.TrimLeft(after, ": \t-")
+		if after != "" {
+			if idx := strings.IndexAny(after, " ,\r\n"); idx >= 0 {
+				instance = after[:idx]
+			} else {
+				instance = after
+			}
+		}
+	}
+	if instance == "" {
+		if match := regexp.MustCompile(`(?i)instance\s*[:=]\s*([^\s,]+)`).FindStringSubmatch(clean); len(match) > 1 {
+			instance = strings.TrimSpace(match[1])
+		}
+	}
+	return RoomEvent{World: world, Instance: instance, RawLine: clean}, true
+}
+
+func isVRChatRunning() bool {
+	tasklist, err := exec.LookPath("tasklist.exe")
+	if err != nil {
+		tasklist, err = exec.LookPath("tasklist")
+		if err != nil {
+			return true // best effort fallback
+		}
+	}
+	cmd := exec.Command(tasklist, "/FI", "IMAGENAME eq VRChat.exe")
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	output, err := cmd.Output()
+	if err != nil {
+		return true
+	}
+	return strings.Contains(strings.ToLower(string(output)), "vrchat.exe")
+}

--- a/internal/app/ui_windows.go
+++ b/internal/app/ui_windows.go
@@ -1,0 +1,605 @@
+//go:build windows
+
+package app
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+)
+
+const (
+	ctrlInstallEdit  uint16 = 1001
+	ctrlLogEdit      uint16 = 1002
+	ctrlUserEdit     uint16 = 1003
+	ctrlTokenEdit    uint16 = 1004
+	ctrlStatusLabel  uint16 = 2001
+	ctrlMonitorLabel uint16 = 2002
+	ctrlCurrentLog   uint16 = 2003
+	ctrlSessionLabel uint16 = 2004
+	ctrlLastEvent    uint16 = 2005
+
+	cmdSaveRestart   uint16 = 3001
+	cmdSaveOnly      uint16 = 3002
+	cmdOpenInstall   uint16 = 3003
+	cmdStart         uint16 = 3004
+	cmdRestart       uint16 = 3005
+	cmdStop          uint16 = 3006
+	cmdQuit          uint16 = 3007
+	cmdBrowseInstall uint16 = 3008
+	cmdBrowseLogs    uint16 = 3009
+)
+
+const (
+	trayCmdOpen    uint16 = 4001
+	trayCmdStart   uint16 = 4002
+	trayCmdRestart uint16 = 4003
+	trayCmdStop    uint16 = 4004
+	trayCmdQuit    uint16 = 4005
+)
+
+var (
+	mainClassName    = "VRChatJoinNotifierWindow"
+	windowProc       = syscall.NewCallback(wndProc)
+	activeController *Controller
+)
+
+// Controller coordinates the Win32 window, tray icon and background workers.
+type Controller struct {
+	cfg      *AppConfig
+	logger   *AppLogger
+	notifier *DesktopNotifier
+	pushover *PushoverClient
+	session  *SessionTracker
+
+	hwnd       syscall.Handle
+	icon       syscall.Handle
+	controls   map[uint16]syscall.Handle
+	tray       *trayIcon
+	monitor    *LogMonitor
+	eventCh    chan MonitorEvent
+	eventMu    sync.Mutex
+	eventQueue []MonitorEvent
+
+	loadNotice string
+	quitting   bool
+}
+
+func NewController(cfg *AppConfig, loadNotice string, logger *AppLogger) (*Controller, error) {
+	controller := &Controller{
+		cfg:        cfg,
+		logger:     logger,
+		notifier:   NewDesktopNotifier(logger),
+		pushover:   NewPushoverClient(cfg, logger),
+		loadNotice: loadNotice,
+		controls:   make(map[uint16]syscall.Handle),
+		eventCh:    make(chan MonitorEvent, 64),
+	}
+	controller.session = NewSessionTracker(controller.notifier, controller.pushover, controller.logger)
+	iconPath := locateNotificationIcon()
+	controller.icon = loadIconFromFile(iconPath)
+	if controller.icon == 0 {
+		controller.icon = loadDefaultIcon()
+	}
+	activeController = controller
+	if err := registerClass(mainClassName, windowProc, controller.icon); err != nil {
+		return nil, fmt.Errorf("register window class: %w", err)
+	}
+	hwnd, err := createWindow(mainClassName, AppName, 820, 520, 0)
+	if err != nil {
+		return nil, fmt.Errorf("create window: %w", err)
+	}
+	controller.hwnd = hwnd
+	controller.createControls()
+	showWindow(controller.hwnd)
+	tray, err := newTrayIcon(controller.hwnd, controller.icon)
+	if err != nil {
+		if controller.logger != nil {
+			controller.logger.Logf("Tray icon disabled: %v", err)
+		}
+	} else {
+		controller.tray = tray
+	}
+	go controller.processEvents()
+	controller.applyStartupState()
+	return controller, nil
+}
+
+func (c *Controller) Run() error {
+	defer c.cleanup()
+	returnCode := messageLoop()
+	if c.logger != nil {
+		c.logger.Logf("Message loop exited with code %d", returnCode)
+	}
+	return nil
+}
+
+func (c *Controller) cleanup() {
+	if c.monitor != nil {
+		c.monitor.Stop()
+		c.monitor = nil
+	}
+	if c.tray != nil {
+		c.tray.dispose()
+		c.tray = nil
+	}
+	close(c.eventCh)
+}
+
+func (c *Controller) createControls() {
+	font := defaultUIFont()
+	xMargin := int32(16)
+	y := int32(18)
+	labelWidth := int32(150)
+	editWidth := int32(420)
+	buttonWidth := int32(140)
+	rowHeight := int32(24)
+	gap := int32(8)
+
+	createLabel := func(text string, x, y, width int32) {
+		ctrl := createControl("STATIC", text, 0, x, y, width, rowHeight, c.hwnd, 0, 0)
+		sendMessage(ctrl, wmSetFont, uintptr(font), 1)
+	}
+	createButton := func(id uint16, text string, x, y int32) {
+		ctrl := createControl("BUTTON", text, bsPushButton|wsTabStop, x, y, buttonWidth, rowHeight+6, c.hwnd, id, 0)
+		sendMessage(ctrl, wmSetFont, uintptr(font), 1)
+		c.controls[id] = ctrl
+	}
+
+	createLabel("Install directory", xMargin, y, labelWidth)
+	installEdit := createControl("EDIT", c.cfg.InstallDir, esAutoHScroll|wsTabStop, xMargin+labelWidth, y-2, editWidth, rowHeight+4, c.hwnd, ctrlInstallEdit, wsExClientEdge)
+	sendMessage(installEdit, wmSetFont, uintptr(font), 1)
+	c.controls[ctrlInstallEdit] = installEdit
+	createButton(cmdBrowseInstall, "Browse...", xMargin+labelWidth+editWidth+gap, y-4)
+
+	y += rowHeight + 18
+
+	createLabel("VRChat log directory", xMargin, y, labelWidth)
+	logEdit := createControl("EDIT", c.cfg.VRChatLogDir, esAutoHScroll|wsTabStop, xMargin+labelWidth, y-2, editWidth, rowHeight+4, c.hwnd, ctrlLogEdit, wsExClientEdge)
+	sendMessage(logEdit, wmSetFont, uintptr(font), 1)
+	c.controls[ctrlLogEdit] = logEdit
+	createButton(cmdBrowseLogs, "Browse...", xMargin+labelWidth+editWidth+gap, y-4)
+
+	y += rowHeight + 18
+
+	createLabel("Pushover user key", xMargin, y, labelWidth)
+	userEdit := createControl("EDIT", c.cfg.PushoverUser, esAutoHScroll|wsTabStop, xMargin+labelWidth, y-2, editWidth, rowHeight+4, c.hwnd, ctrlUserEdit, wsExClientEdge)
+	sendMessage(userEdit, wmSetFont, uintptr(font), 1)
+	c.controls[ctrlUserEdit] = userEdit
+
+	y += rowHeight + 12
+
+	createLabel("Pushover API token", xMargin, y, labelWidth)
+	tokenEdit := createControl("EDIT", c.cfg.PushoverToken, esAutoHScroll|wsTabStop, xMargin+labelWidth, y-2, editWidth, rowHeight+4, c.hwnd, ctrlTokenEdit, wsExClientEdge)
+	sendMessage(tokenEdit, wmSetFont, uintptr(font), 1)
+	c.controls[ctrlTokenEdit] = tokenEdit
+
+	y += rowHeight + 24
+
+	createButton(cmdSaveRestart, "Save & Restart", xMargin, y)
+	createButton(cmdSaveOnly, "Save Only", xMargin+buttonWidth+gap, y)
+	createButton(cmdOpenInstall, "Open Install Folder", xMargin+2*(buttonWidth+gap), y)
+
+	y += rowHeight + 30
+
+	createButton(cmdStart, "Start Monitoring", xMargin, y)
+	createButton(cmdRestart, "Restart Monitoring", xMargin+buttonWidth+gap, y)
+	createButton(cmdStop, "Stop Monitoring", xMargin+2*(buttonWidth+gap), y)
+
+	y += rowHeight + 30
+
+	statusLabel := createControl("STATIC", "Idle", 0, xMargin, y, editWidth+labelWidth+buttonWidth, rowHeight+4, c.hwnd, ctrlStatusLabel, 0)
+	sendMessage(statusLabel, wmSetFont, uintptr(font), 1)
+	c.controls[ctrlStatusLabel] = statusLabel
+
+	y += rowHeight + 8
+	monitorLabel := createControl("STATIC", "Stopped", 0, xMargin, y, editWidth+labelWidth+buttonWidth, rowHeight+4, c.hwnd, ctrlMonitorLabel, 0)
+	sendMessage(monitorLabel, wmSetFont, uintptr(font), 1)
+	c.controls[ctrlMonitorLabel] = monitorLabel
+
+	y += rowHeight + 8
+	logLabel := createControl("STATIC", "(none)", 0, xMargin, y, editWidth+labelWidth+buttonWidth, rowHeight+4, c.hwnd, ctrlCurrentLog, 0)
+	sendMessage(logLabel, wmSetFont, uintptr(font), 1)
+	c.controls[ctrlCurrentLog] = logLabel
+
+	y += rowHeight + 8
+	sessionLabel := createControl("STATIC", "No active session", 0, xMargin, y, editWidth+labelWidth+buttonWidth, rowHeight+4, c.hwnd, ctrlSessionLabel, 0)
+	sendMessage(sessionLabel, wmSetFont, uintptr(font), 1)
+	c.controls[ctrlSessionLabel] = sessionLabel
+
+	y += rowHeight + 8
+	lastEvent := createControl("STATIC", "", 0, xMargin, y, editWidth+labelWidth+buttonWidth, rowHeight+4, c.hwnd, ctrlLastEvent, 0)
+	sendMessage(lastEvent, wmSetFont, uintptr(font), 1)
+	c.controls[ctrlLastEvent] = lastEvent
+}
+
+func (c *Controller) processEvents() {
+	for ev := range c.eventCh {
+		c.eventMu.Lock()
+		c.eventQueue = append(c.eventQueue, ev)
+		c.eventMu.Unlock()
+		postMessage(c.hwnd, wmEventNotify, 0, 0)
+	}
+}
+
+func (c *Controller) drainEvents() []MonitorEvent {
+	c.eventMu.Lock()
+	defer c.eventMu.Unlock()
+	events := make([]MonitorEvent, len(c.eventQueue))
+	copy(events, c.eventQueue)
+	c.eventQueue = c.eventQueue[:0]
+	return events
+}
+
+func (c *Controller) applyStartupState() {
+	if c.loadNotice != "" {
+		c.setStatus(c.loadNotice)
+	}
+	if c.cfg.FirstRun {
+		c.setStatus("Welcome! Configure folders and optional Pushover keys, then click Save & Restart Monitoring.")
+		return
+	}
+	if strings.TrimSpace(c.cfg.PushoverUser) != "" && strings.TrimSpace(c.cfg.PushoverToken) != "" {
+		c.startMonitoring()
+	} else {
+		c.setStatus("Optional: add your Pushover keys then click Save & Restart Monitoring when ready.")
+	}
+}
+
+func (c *Controller) handleEvent(ev MonitorEvent) {
+	switch ev.Type {
+	case EventStatus:
+		c.setStatus(ev.Message)
+	case EventLogSwitch:
+		c.setLabel(ctrlCurrentLog, ev.Path)
+		c.session.HandleLogSwitch(ev.Path)
+		c.setLabel(ctrlSessionLabel, c.session.Summary())
+		c.setStatus("Monitoring " + filepath.Base(ev.Path))
+	case EventError:
+		c.setStatus(ev.Message)
+	case EventRoomEnter:
+		msg := c.session.HandleRoomEnter(ev.Room)
+		c.setStatus(msg)
+		c.setLabel(ctrlSessionLabel, c.session.Summary())
+	case EventRoomLeft:
+		msg := c.session.HandleRoomLeft()
+		c.setStatus(msg)
+		c.setLabel(ctrlSessionLabel, c.session.Summary())
+	case EventSelfJoin:
+		c.session.HandleSelfJoin(ev.Message)
+		c.setLabel(ctrlSessionLabel, c.session.Summary())
+	case EventPlayerJoin:
+		if msg := c.session.HandlePlayerJoin(ev.Player); msg != "" {
+			c.setStatus(msg)
+		}
+	case EventPlayerLeft:
+		if name := c.session.HandlePlayerLeft(ev.Player); name != "" {
+			c.setStatus(fmt.Sprintf("%s left the instance.", name))
+		}
+	}
+	c.setLabel(ctrlLastEvent, c.session.LastEvent())
+	c.updateTray()
+}
+
+func (c *Controller) handleCommand(id uint16) {
+	switch id {
+	case cmdSaveRestart:
+		c.saveAndRestart()
+	case cmdSaveOnly:
+		c.saveOnly()
+	case cmdOpenInstall:
+		if c.logger != nil {
+			c.logger.OpenLogDirectory()
+		}
+	case cmdStart:
+		c.startMonitoring()
+	case cmdRestart:
+		c.restartMonitoring()
+	case cmdStop:
+		c.stopMonitoring()
+	case cmdQuit:
+		c.requestQuit()
+	case cmdBrowseInstall, cmdBrowseLogs:
+		c.setStatus("Enter the folder path manually in the text box.")
+	case trayCmdOpen:
+		c.showWindow()
+	case trayCmdStart:
+		c.startMonitoring()
+	case trayCmdRestart:
+		c.restartMonitoring()
+	case trayCmdStop:
+		c.stopMonitoring()
+	case trayCmdQuit:
+		c.requestQuit()
+	}
+}
+
+func (c *Controller) saveAndRestart() {
+	if err := c.saveConfig(); err != nil {
+		c.setStatus(fmt.Sprintf("Failed to save settings: %v", err))
+		return
+	}
+	c.startMonitoring()
+	c.setStatus("Settings saved & monitoring restarted.")
+}
+
+func (c *Controller) saveOnly() {
+	if err := c.saveConfig(); err != nil {
+		c.setStatus(fmt.Sprintf("Failed to save settings: %v", err))
+		return
+	}
+	c.setStatus("Settings saved.")
+}
+
+func (c *Controller) saveConfig() error {
+	c.cfg.InstallDir = expandPath(c.getText(ctrlInstallEdit))
+	c.cfg.VRChatLogDir = expandPath(c.getText(ctrlLogEdit))
+	c.cfg.PushoverUser = strings.TrimSpace(c.getText(ctrlUserEdit))
+	c.cfg.PushoverToken = strings.TrimSpace(c.getText(ctrlTokenEdit))
+	if err := c.cfg.Save(); err != nil {
+		return err
+	}
+	if c.logger != nil {
+		c.logger.Log("Settings saved.")
+	}
+	return nil
+}
+
+func (c *Controller) startMonitoring() {
+	if c.monitor != nil {
+		return
+	}
+	c.monitor = NewLogMonitor(c.cfg, c.logger, c.eventCh)
+	c.monitor.Start()
+	c.setLabel(ctrlMonitorLabel, "Running")
+	c.setStatus("Monitoring started.")
+	if c.logger != nil {
+		c.logger.Log("Monitoring started.")
+	}
+	c.updateTray()
+}
+
+func (c *Controller) stopMonitoring() {
+	if c.monitor == nil {
+		return
+	}
+	c.monitor.Stop()
+	c.monitor = nil
+	c.session.Reset("Monitoring stopped by user.")
+	c.setLabel(ctrlMonitorLabel, "Stopped")
+	c.setStatus("Monitoring stopped.")
+	c.setLabel(ctrlCurrentLog, "(none)")
+	c.setLabel(ctrlSessionLabel, "No active session")
+	c.setLabel(ctrlLastEvent, "")
+	if c.logger != nil {
+		c.logger.Log("Monitoring stopped.")
+	}
+	c.updateTray()
+}
+
+func (c *Controller) restartMonitoring() {
+	c.stopMonitoring()
+	c.startMonitoring()
+	c.setStatus("Monitoring restarted.")
+	if c.logger != nil {
+		c.logger.Log("Monitoring restarted.")
+	}
+}
+
+func (c *Controller) setStatus(text string) {
+	c.setLabel(ctrlStatusLabel, text)
+}
+
+func (c *Controller) setLabel(id uint16, text string) {
+	if hwnd, ok := c.controls[id]; ok {
+		setWindowText(hwnd, text)
+	}
+}
+
+func (c *Controller) getText(id uint16) string {
+	if hwnd, ok := c.controls[id]; ok {
+		return strings.TrimSpace(getWindowText(hwnd))
+	}
+	return ""
+}
+
+func (c *Controller) updateTray() {
+	if c.tray == nil {
+		return
+	}
+	monitoring := c.monitor != nil
+	summary := c.session.Summary()
+	tooltip := AppName
+	if monitoring {
+		tooltip = AppName + " - Monitoring"
+	} else {
+		tooltip = AppName + " - Stopped"
+	}
+	if summary != "" {
+		tooltip += "\n" + summary
+	}
+	_ = c.tray.setTooltip(tooltip)
+	c.tray.setMonitoring(monitoring)
+}
+
+func (c *Controller) showWindow() {
+	showWindow(c.hwnd)
+}
+
+func (c *Controller) hideWindow() {
+	hideWindow(c.hwnd)
+}
+
+func (c *Controller) requestQuit() {
+	if c.quitting {
+		return
+	}
+	c.quitting = true
+	c.stopMonitoring()
+	destroyWindow(c.hwnd)
+}
+
+func wndProc(hwnd syscall.Handle, msg uint32, wparam, lparam uintptr) uintptr {
+	if activeController != nil && activeController.hwnd == hwnd {
+		return activeController.handleMessage(msg, wparam, lparam)
+	}
+	if msg == wmDestroy {
+		postQuitMessage(0)
+		return 0
+	}
+	return defWindowProc(hwnd, msg, wparam, lparam)
+}
+
+func (c *Controller) handleMessage(msg uint32, wparam, lparam uintptr) uintptr {
+	switch msg {
+	case wmCommand:
+		id := uint16(wparam & 0xFFFF)
+		c.handleCommand(id)
+		return 0
+	case wmTrayMessage:
+		switch lparam {
+		case 0x0202: // WM_LBUTTONUP
+			c.showWindow()
+		case 0x0205: // WM_RBUTTONUP
+			c.showTrayMenu()
+		}
+		return 0
+	case wmEventNotify:
+		events := c.drainEvents()
+		for _, ev := range events {
+			c.handleEvent(ev)
+		}
+		return 0
+	case wmClose:
+		if !c.quitting {
+			c.hideWindow()
+			return 0
+		}
+	case wmDestroy:
+		activeController = nil
+		postQuitMessage(0)
+		return 0
+	}
+	return defWindowProc(c.hwnd, msg, wparam, lparam)
+}
+
+func (c *Controller) showTrayMenu() {
+	if c.tray == nil {
+		return
+	}
+	c.tray.showMenu()
+}
+
+// locateNotificationIcon searches common paths for notification.ico.
+func locateNotificationIcon() string {
+	candidates := []string{}
+	if exe, err := osExecutable(); err == nil {
+		dir := filepath.Dir(exe)
+		candidates = append(candidates,
+			filepath.Join(dir, IconFileName),
+			filepath.Join(dir, "vrchat_join_notification", IconFileName),
+		)
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		candidates = append(candidates,
+			filepath.Join(cwd, IconFileName),
+			filepath.Join(cwd, "vrchat_join_notification", IconFileName),
+		)
+	}
+	for _, candidate := range candidates {
+		if fileExists(candidate) {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func osExecutable() (string, error) {
+	return os.Executable()
+}
+
+type trayIcon struct {
+	hwnd       syscall.Handle
+	icon       syscall.Handle
+	menu       syscall.Handle
+	added      bool
+	monitoring bool
+}
+
+func newTrayIcon(hwnd syscall.Handle, icon syscall.Handle) (*trayIcon, error) {
+	t := &trayIcon{hwnd: hwnd, icon: icon}
+	menu := makeMenu()
+	appendMenu(menu, mfString, trayCmdOpen, "Open Settings")
+	appendMenu(menu, mfString, trayCmdStart, "Start Monitoring")
+	appendMenu(menu, mfString, trayCmdRestart, "Restart Monitoring")
+	appendMenu(menu, mfString, trayCmdStop, "Stop Monitoring")
+	appendMenu(menu, mfSeparator, 0, "")
+	appendMenu(menu, mfString, trayCmdQuit, "Quit")
+	t.menu = menu
+	if err := t.setTooltip(AppName); err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+func (t *trayIcon) setMonitoring(active bool) {
+	t.monitoring = active
+}
+
+func (t *trayIcon) setTooltip(text string) error {
+	var data notifyIconData
+	data.HWnd = t.hwnd
+	data.ID = 1
+	data.Flags = nifMessage | nifIcon | nifTip
+	data.CallbackMsg = wmTrayMessage
+	data.HIcon = t.icon
+	copyUTF16(data.Tip[:], text)
+	if !t.added {
+		if err := shellNotifyIcon(nidAdd, &data); err != nil {
+			return err
+		}
+		data.TimeoutOrVersion = 4
+		_ = shellNotifyIcon(0x00000004, &data)
+		t.added = true
+	} else {
+		if err := shellNotifyIcon(nidModify, &data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *trayIcon) showMenu() {
+	if t.menu == 0 {
+		return
+	}
+	p, ok := getCursorPos()
+	if !ok {
+		return
+	}
+	trackPopupMenu(t.menu, 0x0000|0x0002, p.X, p.Y, t.hwnd)
+}
+
+func (t *trayIcon) dispose() {
+	if t.added {
+		var data notifyIconData
+		data.HWnd = t.hwnd
+		data.ID = 1
+		_ = shellNotifyIcon(nidDelete, &data)
+		t.added = false
+	}
+}
+
+func copyUTF16(dest []uint16, text string) {
+	runes := syscall.StringToUTF16(text)
+	max := len(dest)
+	for i := 0; i < max && i < len(runes)-1; i++ {
+		dest[i] = runes[i]
+	}
+	if max > 0 {
+		dest[max-1] = 0
+	}
+}

--- a/internal/app/win32_windows.go
+++ b/internal/app/win32_windows.go
@@ -1,0 +1,386 @@
+//go:build windows
+
+package app
+
+import (
+	"errors"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	modUser32   = syscall.NewLazyDLL("user32.dll")
+	modKernel32 = syscall.NewLazyDLL("kernel32.dll")
+	modShell32  = syscall.NewLazyDLL("shell32.dll")
+	modGdi32    = syscall.NewLazyDLL("gdi32.dll")
+)
+
+var (
+	procRegisterClassEx    = modUser32.NewProc("RegisterClassExW")
+	procCreateWindowEx     = modUser32.NewProc("CreateWindowExW")
+	procDefWindowProc      = modUser32.NewProc("DefWindowProcW")
+	procDestroyWindow      = modUser32.NewProc("DestroyWindow")
+	procShowWindow         = modUser32.NewProc("ShowWindow")
+	procUpdateWindow       = modUser32.NewProc("UpdateWindow")
+	procGetMessage         = modUser32.NewProc("GetMessageW")
+	procTranslateMessage   = modUser32.NewProc("TranslateMessage")
+	procDispatchMessage    = modUser32.NewProc("DispatchMessageW")
+	procPostQuitMessage    = modUser32.NewProc("PostQuitMessage")
+	procSendMessage        = modUser32.NewProc("SendMessageW")
+	procSetWindowText      = modUser32.NewProc("SetWindowTextW")
+	procGetWindowText      = modUser32.NewProc("GetWindowTextW")
+	procGetWindowTextLen   = modUser32.NewProc("GetWindowTextLengthW")
+	procCreateMenu         = modUser32.NewProc("CreatePopupMenu")
+	procAppendMenu         = modUser32.NewProc("AppendMenuW")
+	procTrackPopupMenu     = modUser32.NewProc("TrackPopupMenu")
+	procSetForegroundWnd   = modUser32.NewProc("SetForegroundWindow")
+	procGetCursorPos       = modUser32.NewProc("GetCursorPos")
+	procLoadCursor         = modUser32.NewProc("LoadCursorW")
+	procLoadIcon           = modUser32.NewProc("LoadIconW")
+	procLoadImage          = modUser32.NewProc("LoadImageW")
+	procSendDlgItemMessage = modUser32.NewProc("SendMessageW")
+	procSetWindowPos       = modUser32.NewProc("SetWindowPos")
+	procGetClientRect      = modUser32.NewProc("GetClientRect")
+	procMoveWindow         = modUser32.NewProc("MoveWindow")
+	procShellNotifyIcon    = modShell32.NewProc("Shell_NotifyIconW")
+	procGetStockObject     = modGdi32.NewProc("GetStockObject")
+	procPostMessage        = modUser32.NewProc("PostMessageW")
+	procMessageBox         = modUser32.NewProc("MessageBoxW")
+	procCreateMutex        = modKernel32.NewProc("CreateMutexW")
+	procReleaseMutex       = modKernel32.NewProc("ReleaseMutex")
+	procCloseHandle        = modKernel32.NewProc("CloseHandle")
+)
+
+const (
+	wsOverlappedWindow = 0x00CF0000
+	wsVisible          = 0x10000000
+	wsChild            = 0x40000000
+	wsTabStop          = 0x00010000
+	wsExAppWindow      = 0x00040000
+	wsExClientEdge     = 0x00000200
+
+	cwUseDefault = 0x80000000
+
+	wmDestroy = 0x0002
+	wmClose   = 0x0010
+	wmCommand = 0x0111
+	wmApp     = 0x8000
+	wmUser    = 0x0400
+	wmSetFont = 0x0030
+
+	swShow = 5
+
+	bsPushButton  = 0x00000000
+	esAutoHScroll = 0x0004
+
+	mfString    = 0x00000000
+	mfSeparator = 0x00000800
+
+	niifInfo   = 0x00000001
+	nifMessage = 0x00000001
+	nifIcon    = 0x00000002
+	nifTip     = 0x00000004
+	nidAdd     = 0x00000000
+	nidModify  = 0x00000001
+	nidDelete  = 0x00000002
+
+	mbOK              = 0x00000000
+	mbIconInformation = 0x00000040
+	mbIconWarning     = 0x00000030
+	mbIconError       = 0x00000010
+)
+
+type wndClassEx struct {
+	Size       uint32
+	Style      uint32
+	WndProc    uintptr
+	ClsExtra   int32
+	WndExtra   int32
+	Instance   syscall.Handle
+	Icon       syscall.Handle
+	Cursor     syscall.Handle
+	Background syscall.Handle
+	MenuName   *uint16
+	ClassName  *uint16
+	IconSm     syscall.Handle
+}
+
+type point struct {
+	X int32
+	Y int32
+}
+
+type msg struct {
+	Hwnd    syscall.Handle
+	Message uint32
+	WParam  uintptr
+	LParam  uintptr
+	Time    uint32
+	Pt      point
+}
+
+type rect struct {
+	Left   int32
+	Top    int32
+	Right  int32
+	Bottom int32
+}
+
+type notifyIconData struct {
+	Size             uint32
+	HWnd             syscall.Handle
+	ID               uint32
+	Flags            uint32
+	CallbackMsg      uint32
+	HIcon            syscall.Handle
+	Tip              [128]uint16
+	State            uint32
+	StateMask        uint32
+	Info             [256]uint16
+	TimeoutOrVersion uint32
+	InfoTitle        [64]uint16
+	InfoFlags        uint32
+	GUIDItem         [16]byte
+	BalloonIcon      syscall.Handle
+}
+
+func registerClass(className string, wndProc uintptr, icon syscall.Handle) error {
+	hInstance, _, _ := modKernel32.NewProc("GetModuleHandleW").Call(0)
+	clsName, _ := syscall.UTF16PtrFromString(className)
+	cursor, _, _ := procLoadCursor.Call(0, uintptr(32512))
+	wc := wndClassEx{
+		Size:       uint32(unsafe.Sizeof(wndClassEx{})),
+		Style:      0,
+		WndProc:    wndProc,
+		ClsExtra:   0,
+		WndExtra:   0,
+		Instance:   syscall.Handle(hInstance),
+		Icon:       icon,
+		Cursor:     syscall.Handle(cursor),
+		Background: 6, // COLOR_WINDOW
+		MenuName:   nil,
+		ClassName:  clsName,
+		IconSm:     icon,
+	}
+	atom, _, err := procRegisterClassEx.Call(uintptr(unsafe.Pointer(&wc)))
+	if atom == 0 {
+		return err
+	}
+	return nil
+}
+
+func createWindow(className, title string, width, height int32, param uintptr) (syscall.Handle, error) {
+	hInstance, _, _ := modKernel32.NewProc("GetModuleHandleW").Call(0)
+	clsName, _ := syscall.UTF16PtrFromString(className)
+	wndTitle, _ := syscall.UTF16PtrFromString(title)
+	hwnd, _, err := procCreateWindowEx.Call(
+		wsExAppWindow,
+		uintptr(unsafe.Pointer(clsName)),
+		uintptr(unsafe.Pointer(wndTitle)),
+		wsOverlappedWindow|wsVisible,
+		uintptr(cwUseDefault),
+		uintptr(cwUseDefault),
+		uintptr(width),
+		uintptr(height),
+		0,
+		0,
+		hInstance,
+		param,
+	)
+	if hwnd == 0 {
+		return 0, err
+	}
+	return syscall.Handle(hwnd), nil
+}
+
+func showWindow(hwnd syscall.Handle) {
+	procShowWindow.Call(uintptr(hwnd), swShow)
+	procUpdateWindow.Call(uintptr(hwnd))
+}
+
+func hideWindow(hwnd syscall.Handle) {
+	procShowWindow.Call(uintptr(hwnd), 0)
+}
+
+func messageLoop() int {
+	var m msg
+	for {
+		ret, _, _ := procGetMessage.Call(uintptr(unsafe.Pointer(&m)), 0, 0, 0)
+		switch int32(ret) {
+		case -1:
+			return -1
+		case 0:
+			return int(m.WParam)
+		default:
+			procTranslateMessage.Call(uintptr(unsafe.Pointer(&m)))
+			procDispatchMessage.Call(uintptr(unsafe.Pointer(&m)))
+		}
+	}
+}
+
+func defWindowProc(hwnd syscall.Handle, msg uint32, wparam, lparam uintptr) uintptr {
+	ret, _, _ := procDefWindowProc.Call(uintptr(hwnd), uintptr(msg), wparam, lparam)
+	return ret
+}
+
+func postQuitMessage(code int32) {
+	procPostQuitMessage.Call(uintptr(code))
+}
+
+func destroyWindow(hwnd syscall.Handle) {
+	procDestroyWindow.Call(uintptr(hwnd))
+}
+
+func setWindowText(hwnd syscall.Handle, text string) {
+	ptr, _ := syscall.UTF16PtrFromString(text)
+	procSetWindowText.Call(uintptr(hwnd), uintptr(unsafe.Pointer(ptr)))
+}
+
+func getWindowText(hwnd syscall.Handle) string {
+	length, _, _ := procGetWindowTextLen.Call(uintptr(hwnd))
+	buf := make([]uint16, length+1)
+	procGetWindowText.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&buf[0])), length+1)
+	return syscall.UTF16ToString(buf)
+}
+
+func sendMessage(hwnd syscall.Handle, msg uint32, wparam, lparam uintptr) uintptr {
+	ret, _, _ := procSendMessage.Call(uintptr(hwnd), uintptr(msg), wparam, lparam)
+	return ret
+}
+
+func setWindowPos(hwnd syscall.Handle, x, y, cx, cy int32, flags uintptr) {
+	procSetWindowPos.Call(uintptr(hwnd), 0, uintptr(x), uintptr(y), uintptr(cx), uintptr(cy), flags)
+}
+
+func moveWindow(hwnd syscall.Handle, x, y, cx, cy int32, repaint bool) {
+	repaintFlag := uintptr(0)
+	if repaint {
+		repaintFlag = 1
+	}
+	procMoveWindow.Call(uintptr(hwnd), uintptr(x), uintptr(y), uintptr(cx), uintptr(cy), repaintFlag)
+}
+
+func getClientRect(hwnd syscall.Handle) rect {
+	var r rect
+	procGetClientRect.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&r)))
+	return r
+}
+
+var errNotifyIcon = errors.New("shell notify icon failed")
+
+func shellNotifyIcon(msg uint32, data *notifyIconData) error {
+	data.Size = uint32(unsafe.Sizeof(*data))
+	ret, _, err := procShellNotifyIcon.Call(uintptr(msg), uintptr(unsafe.Pointer(data)))
+	if ret == 0 {
+		if err != syscall.Errno(0) {
+			return err
+		}
+		return errNotifyIcon
+	}
+	return nil
+}
+
+func loadIconFromFile(path string) syscall.Handle {
+	if path == "" {
+		return 0
+	}
+	ptr, _ := syscall.UTF16PtrFromString(path)
+	handle, _, _ := procLoadImage.Call(0, uintptr(unsafe.Pointer(ptr)), 1, 0, 0, 0x00000010|0x00000080)
+	return syscall.Handle(handle)
+}
+
+func loadDefaultIcon() syscall.Handle {
+	handle, _, _ := procLoadIcon.Call(0, 32512) // IDI_APPLICATION
+	return syscall.Handle(handle)
+}
+
+func getCursorPos() (point, bool) {
+	var p point
+	ret, _, _ := procGetCursorPos.Call(uintptr(unsafe.Pointer(&p)))
+	return p, ret != 0
+}
+
+const (
+	swpNoZOrder   = 0x0004
+	swpNoActivate = 0x0010
+)
+
+const (
+	wmTrayMessage = wmApp + 1
+	wmEventNotify = wmApp + 2
+)
+
+func makeMenu() syscall.Handle {
+	menu, _, _ := procCreateMenu.Call()
+	return syscall.Handle(menu)
+}
+
+func appendMenu(menu syscall.Handle, flags uint32, id uint16, text string) {
+	ptr, _ := syscall.UTF16PtrFromString(text)
+	procAppendMenu.Call(uintptr(menu), uintptr(flags), uintptr(id), uintptr(unsafe.Pointer(ptr)))
+}
+
+func trackPopupMenu(menu syscall.Handle, flags uint32, x, y int32, hwnd syscall.Handle) {
+	procSetForegroundWnd.Call(uintptr(hwnd))
+	procTrackPopupMenu.Call(uintptr(menu), uintptr(flags), uintptr(x), uintptr(y), 0, uintptr(hwnd), 0)
+}
+
+func defaultUIFont() syscall.Handle {
+	handle, _, _ := procGetStockObject.Call(17) // DEFAULT_GUI_FONT
+	return syscall.Handle(handle)
+}
+
+func createControl(className, text string, style uint32, x, y, width, height int32, parent syscall.Handle, id uint16, exStyle uint32) syscall.Handle {
+	clsPtr, _ := syscall.UTF16PtrFromString(className)
+	txtPtr, _ := syscall.UTF16PtrFromString(text)
+	hwnd, _, _ := procCreateWindowEx.Call(
+		uintptr(exStyle),
+		uintptr(unsafe.Pointer(clsPtr)),
+		uintptr(unsafe.Pointer(txtPtr)),
+		uintptr(style|wsChild|wsVisible),
+		uintptr(x),
+		uintptr(y),
+		uintptr(width),
+		uintptr(height),
+		uintptr(parent),
+		uintptr(id),
+		0,
+		0,
+	)
+	return syscall.Handle(hwnd)
+}
+
+func postMessage(hwnd syscall.Handle, msg uint32, wparam, lparam uintptr) {
+	procPostMessage.Call(uintptr(hwnd), uintptr(msg), wparam, lparam)
+}
+
+func messageBox(hwnd syscall.Handle, text, title string, flags uint32) int {
+	txtPtr, _ := syscall.UTF16PtrFromString(text)
+	titlePtr, _ := syscall.UTF16PtrFromString(title)
+	ret, _, _ := procMessageBox.Call(uintptr(hwnd), uintptr(unsafe.Pointer(txtPtr)), uintptr(unsafe.Pointer(titlePtr)), uintptr(flags))
+	return int(ret)
+}
+
+func createNamedMutex(name string) (syscall.Handle, syscall.Errno) {
+	ptr, _ := syscall.UTF16PtrFromString(name)
+	handle, _, err := procCreateMutex.Call(0, 0, uintptr(unsafe.Pointer(ptr)))
+	if handle == 0 {
+		if errno, ok := err.(syscall.Errno); ok {
+			return 0, errno
+		}
+		return 0, syscall.Errno(0)
+	}
+	return syscall.Handle(handle), 0
+}
+
+func releaseMutex(handle syscall.Handle) {
+	if handle != 0 {
+		procReleaseMutex.Call(uintptr(handle))
+	}
+}
+
+func closeHandle(handle syscall.Handle) {
+	if handle != 0 {
+		procCloseHandle.Call(uintptr(handle))
+	}
+}


### PR DESCRIPTION
## Summary
- implement a native Go watcher for Windows with task-tray controls and configuration GUI
- port VRChat log parsing, session tracking, notifications, and Pushover integration to Go
- document Go build instructions in the README for compiling the Windows tray binary

## Testing
- GOOS=windows go build ./...


------
https://chatgpt.com/codex/tasks/task_e_68cd6092738c832c86ba2aab0ec81897