### PR TITLE
Fix Unicode regex escapes for Go 1.24

### DIFF
--- a/internal/app/session.go
+++ b/internal/app/session.go
@@ -28,8 +28,8 @@ type PlayerEvent struct {
 }
 
 var (
-	zeroWidthPattern      = regexp.MustCompile(`[\u200b-\u200d\ufeff]`)
-	joinSeparatorPattern  = regexp.MustCompile(`^[-:|\u2013\u2014]+$`)
+	zeroWidthPattern      = regexp.MustCompile(`[\x{200b}-\x{200d}\x{feff}]`)
+	joinSeparatorPattern  = regexp.MustCompile(`^[-:|\x{2013}\x{2014}]+$`)
 	displayNamePattern    = regexp.MustCompile(`(?i)displayName\s*[:=]\s*([^,\]\)]+)`)
 	namePattern           = regexp.MustCompile(`(?i)\bname\s*[:=]\s*([^,\]\)]+)`)
 	userIDParenPattern    = regexp.MustCompile(`(?i)\(usr_[^\)\s]+\)`)


### PR DESCRIPTION
## Summary
- replace the Unicode escapes in the zero-width and join-separator regular expressions with \x{...} notation to keep them valid under Go 1.24

## Testing
- GOOS=windows GOARCH=amd64 go build -o /tmp/vrchat-notifier.exe ./cmd/vrchat-notifier

------
https://chatgpt.com/codex/tasks/task_e_68cd684f9698832cac9284046e2de314