### PR TITLE
Lock Windows UI thread to the creating OS thread

### DIFF
--- a/cmd/vrchat-notifier/main_windows.go
+++ b/cmd/vrchat-notifier/main_windows.go
@@ -5,11 +5,15 @@ package main
 import (
 	"errors"
 	"fmt"
+	"runtime"
 
 	"vrchat-join-notification-with-pushover/internal/app"
 )
 
 func main() {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	guard, err := app.AcquireSingleInstance("VRChatJoinNotificationWithPushover")
 	if err != nil {
 		if errors.Is(err, app.ErrAlreadyRunning) {


### PR DESCRIPTION
## Summary
- lock the Windows entry point to its OS thread so the Win32 window and message loop stay on the same thread

## Testing
- `go test ./...` *(fails: linux build of internal/app uses syscall.SysProcAttr without HideWindow field)*
- `GOOS=windows go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68cd701ee090832c830525e2eea5183b