### PR TITLE
Fix Windows single instance guard and tray icon

### DIFF
--- a/src/vrchat-join-notification-with-pushover_windows.py
+++ b/src/vrchat-join-notification-with-pushover_windows.py
@@ -31,7 +31,7 @@ import tracemalloc
 from pathlib import Path
 from typing import Optional, Type
 
-from vrchat_join_notification.app import main
+from vrchat_join_notification.app import ensure_tray_icon_file, main
 
 
 def _log(message: str) -> None:
@@ -212,6 +212,10 @@ class AntiCheatGuard(contextlib.AbstractContextManager["AntiCheatGuard"]):
 
 def _locate_notification_icon() -> Optional[str]:
     """Locate ``notification.ico`` on disk for taskbar usage."""
+
+    ensured = ensure_tray_icon_file()
+    if ensured:
+        return ensured
 
     candidate_paths = []
     script_path = Path(__file__).resolve()


### PR DESCRIPTION
## Summary
- ensure the Windows instance guard stores its lock in the persistent app data directory and reports the blocking PID when duplicate launches are attempted
- add helpers that extract the notification icon to disk and reuse them from the native tray backend and Windows entrypoint so that the tray/taskbar icon is always available

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cde266ac0c832cbf4edf46ecc099a7