### PR TITLE
Fix system tray window creation call

### DIFF
--- a/internal/app/system_tray_windows.go
+++ b/internal/app/system_tray_windows.go
@@ -88,7 +88,7 @@ func (t *SystemTray) run(iconPath string) {
 			return
 		}
 	}
-	hwnd, err := createWindow(className, tooltipOrDefault(t.tooltip), 0, 0, 0, 0, 0)
+	hwnd, err := createWindow(className, tooltipOrDefault(t.tooltip), 0, 0, 0)
 	if err != nil {
 		t.ready <- err
 		return


### PR DESCRIPTION
## Summary
- update the tray window creation call to match the current win32 helper signature

## Testing
- GOOS=windows GOARCH=amd64 go build -o bin/VRChatJoinNotificationWithPushover.exe ./cmd/VRChatJoinNotificationWithPushover *(fails: unable to download fyne.io/fyne/v2 dependencies due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68ce00daada0832caef0e94319267036