### PR TITLE
Hide invisible tray host window

### DIFF
--- a/internal/app/system_tray_windows.go
+++ b/internal/app/system_tray_windows.go
@@ -88,7 +88,7 @@ func (t *SystemTray) run(iconPath string) {
 			return
 		}
 	}
-	hwnd, err := createWindow(className, tooltipOrDefault(t.tooltip), 0, 0, 0)
+	hwnd, err := createWindow(className, tooltipOrDefault(t.tooltip), 0, 0, 0, false)
 	if err != nil {
 		t.ready <- err
 		return

--- a/internal/app/win32_windows.go
+++ b/internal/app/win32_windows.go
@@ -203,15 +203,21 @@ func registerClass(className string, wndProc uintptr, icon syscall.Handle) error
 	return nil
 }
 
-func createWindow(className, title string, width, height int32, param uintptr) (syscall.Handle, error) {
+func createWindow(className, title string, width, height int32, param uintptr, visible bool) (syscall.Handle, error) {
 	hInstance, _, _ := modKernel32.NewProc("GetModuleHandleW").Call(0)
 	clsName, _ := syscall.UTF16PtrFromString(className)
 	wndTitle, _ := syscall.UTF16PtrFromString(title)
+	exStyle := uintptr(0)
+	style := uintptr(wsOverlappedWindow)
+	if visible {
+		exStyle = uintptr(wsExAppWindow)
+		style |= wsVisible
+	}
 	hwnd, _, err := procCreateWindowEx.Call(
-		wsExAppWindow,
+		exStyle,
 		uintptr(unsafe.Pointer(clsName)),
 		uintptr(unsafe.Pointer(wndTitle)),
-		wsOverlappedWindow|wsVisible,
+		style,
 		uintptr(cwUseDefault),
 		uintptr(cwUseDefault),
 		uintptr(width),


### PR DESCRIPTION
## Summary
- prevent the Windows tray backend from creating a visible helper window by default
- make the Win32 createWindow helper configurable so the tray host window stays hidden

## Testing
- `go test ./...`
- `GOOS=windows go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ce0255be30832ca682433436a8c83c