### PR TITLE
Fix Windows startup entry path to use user AppData

### DIFF
--- a/internal/app/ui_windows.go
+++ b/internal/app/ui_windows.go
@@ -634,9 +634,18 @@ func startupShortcutPath() (string, error) {
 }
 
 func startupDirectory() (string, error) {
-	base := strings.TrimSpace(os.Getenv("ProgramData"))
+	base := strings.TrimSpace(os.Getenv("APPDATA"))
 	if base == "" {
-		base = `C:\\ProgramData`
+		if dir, err := os.UserConfigDir(); err == nil {
+			base = strings.TrimSpace(dir)
+		}
+	}
+	if base == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			base = filepath.Join(home, "AppData", "Roaming")
+		} else {
+			return "", fmt.Errorf("unable to determine user application data directory: %w", err)
+		}
 	}
 	dir := filepath.Join(base, "Microsoft", "Windows", "Start Menu", "Programs", "Startup")
 	return dir, nil


### PR DESCRIPTION
## Summary
- create Windows startup shortcuts in the current user's AppData roaming folder instead of ProgramData
- fall back to Go's user config directory or the user's home directory if APPDATA is unavailable

## Testing
- go test ./... *(hangs under Linux container, terminated after waiting)*

------
https://chatgpt.com/codex/tasks/task_e_68ce13a32a68832ca5eb576018d7f66d